### PR TITLE
feat: Added Nix Flake support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1670152712,
+        "narHash": "sha256-LJttwIvJqsZIj8u1LxVRv82vwUtkzVqQVi7Wb8gxPS4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "14ddeaebcbe9a25748221d1d7ecdf98e20e2325e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "Wallpaper daemon for Wayland";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    inputs @ { self
+    , nixpkgs
+    , ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+      genSystems = lib.genAttrs [
+        "x86_64-linux"
+      ];
+
+      pkgsFor = genSystems (system:
+        import nixpkgs {
+          inherit system;
+        });
+
+      mkDate = longDate: (lib.concatStringsSep "-" [
+        (builtins.substring 0 4 longDate)
+        (builtins.substring 4 2 longDate)
+        (builtins.substring 6 2 longDate)
+      ]);
+    in
+    {
+      overlays.default = _: prev: rec {
+        wpaperd = prev.callPackage ./nix/default.nix {
+          version = "0.2.0" + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
+        };
+      };
+      packages = genSystems
+        (system:
+          (self.overlays.default null pkgsFor.${system})
+          // {
+            default = self.packages.${system}.wpaperd;
+          });
+    };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,48 @@
+{ config
+, lib
+, pkgs
+, rustPlatform
+, version
+, pkg-config
+, libxkbcommon
+, ...
+}:
+
+rustPlatform.buildRustPackage rec {
+  inherit version;
+  pname = "wpaperd";
+
+  src = lib.cleanSourceWith {
+    filter = name: type:
+      let
+        baseName = baseNameOf (toString name);
+      in
+        ! (
+          lib.hasSuffix ".nix" baseName
+        );
+    src = lib.cleanSource ../.;
+  };
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    outputHashes = {
+      "timer-0.2.0" = "sha256-yofy6Wszf6EwNGGdVDWNG0RcbpvBgv5/BdOjAFxghwc=";
+    };
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libxkbcommon
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Narice/wpaperd";
+    description = "Wallpaper daemon for Wayland";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    mainProgram = "wpaperd";
+  };
+}


### PR DESCRIPTION
Added Nix Flake support to this repository so that anyone using Nix can use this project.
Tested on my own system, works really well, thanks for the tool, it's awesome!

oh, also, if it's were possible to own a cachix instance, it would mean that Nix results would be cached (and so the build would be done once only).
I can take care of everything, or you can take the free instance for open source [here](https://www.cachix.org/), and I can take care of the GitHub Action setup. As you wish!