### PR TITLE
fix: Set correct scale factor to the initial surface configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn run(config: Config, xdg_dirs: BaseDirectories) -> Result<()> {
     loop {
         let now = Instant::now();
         let mut configured = HashSet::new();
-        let all_configured = if wpaperd.surfaces.is_empty() {
+        let all_configured = if !wpaperd.surfaces.is_empty() {
             wpaperd
                 .surfaces
                 .iter_mut()

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -35,7 +35,6 @@ pub struct Surface {
     pub time_changed: Instant,
     pub current_img: PathBuf,
     pub info: OutputInfo,
-    pub first_configure: bool,
     pub configured: bool,
 }
 
@@ -71,7 +70,7 @@ impl Surface {
             output,
             layer,
             dimensions: (0, 0),
-            scale: 1,
+            scale: info.scale_factor,
             pool,
             surface,
             info,
@@ -80,7 +79,6 @@ impl Surface {
             timer_expired: true,
             time_changed: Instant::now(),
             current_img: PathBuf::from("/"),
-            first_configure: false,
             configured: false,
         }
     }

--- a/src/wpaperd.rs
+++ b/src/wpaperd.rs
@@ -67,10 +67,13 @@ impl CompositorHandler for Wpaperd {
             .find(|(_, s)| surface == &s.surface)
             .unwrap()
             .1;
-        surface.scale = new_factor;
-        surface.surface.set_buffer_scale(new_factor);
-        surface.need_redraw = true;
-        surface.configured = true;
+
+        // Ignore unnecessary updates
+        if surface.scale != new_factor {
+            surface.scale = new_factor;
+            surface.surface.set_buffer_scale(new_factor);
+            surface.need_redraw = true;
+        }
     }
 
     fn frame(
@@ -165,19 +168,14 @@ impl LayerShellHandler for Wpaperd {
             .find(|surface| &surface.layer == layer)
             // We always know the surface that it is being configured
             .unwrap();
-        debug_assert!(configure.new_size.0 == 0 || configure.new_size.1 == 0);
+
         if surface.dimensions != configure.new_size {
+            // Update dimensions
+            surface.dimensions = configure.new_size;
             surface.need_redraw = true;
         }
 
-        // Update dimensions
-        surface.dimensions = configure.new_size;
-
-        if !surface.first_configure {
-            surface.first_configure = true;
-        } else if !surface.configured && surface.info.scale_factor == 1 {
-            surface.configured = true;
-        }
+        surface.configured = true;
     }
 }
 


### PR DESCRIPTION
I describe my issue in depth in #23 but from my testing it seems like `wpaperd` runs  correctly with these changes.

Here's a brief list of my changes:
 - The flipped condition in the first `loop` in `main::run` seems like a typo
 - In `src/surface.rs` I set the initial `scale` of the surface to `info.scale_factor` instead of 1
 - The "big" change in logic is in `src/wpaperd.rs` where:
   - Receiving a `scale_factor_changed` event no longer sets the surface as configured
   - Receiving a `configure` event (even if it is the first one) sets the surface as configured 

PS. It's my first time working with the Wayland protocol so I'm not sure I correctly understand the sequence of events `wpaperd` should receive but I found your program really easy to debug because of its structure and after I found the `WAYLAND_DEBUG=1` flag, so thanks for the learning exercise!

Should close #23 

<details>
  <summary>wpaperd running with `RUST_LOG=trace WAYLAND_DEBUG=1`</summary>

```
[1676946581.588283] -> wl_display@1.get_registry (wl_registry@2)
[1676946581.588302] -> wl_display@1.sync (wl_callback@3)
[1676946581.588363] <- wl_registry@2.global, (1, Some("wl_shm"), 1)
[1676946581.588380] <- wl_registry@2.global, (2, Some("wl_drm"), 2)
[1676946581.588396] <- wl_registry@2.global, (3, Some("zwp_linux_dmabuf_v1"), 4)
[1676946581.588421] <- wl_registry@2.global, (4, Some("wl_compositor"), 5)
[1676946581.588440] <- wl_registry@2.global, (5, Some("wl_subcompositor"), 1)
[1676946581.588460] <- wl_registry@2.global, (6, Some("wl_data_device_manager"), 3)
[1676946581.588482] <- wl_registry@2.global, (7, Some("zwlr_export_dmabuf_manager_v1"), 1)
[1676946581.588505] <- wl_registry@2.global, (8, Some("zwlr_screencopy_manager_v1"), 3)
[1676946581.588528] <- wl_registry@2.global, (9, Some("zwlr_data_control_manager_v1"), 2)
[1676946581.588554] <- wl_registry@2.global, (10, Some("zwlr_gamma_control_manager_v1"), 1)
[1676946581.588581] <- wl_registry@2.global, (11, Some("zwp_primary_selection_device_manager_v1"), 1)
[1676946581.588611] <- wl_registry@2.global, (12, Some("wp_viewporter"), 1)
[1676946581.588630] <- wl_registry@2.global, (13, Some("zwlr_output_power_manager_v1"), 1)
[1676946581.588660] <- wl_registry@2.global, (14, Some("xdg_wm_base"), 5)
[1676946581.588677] <- wl_registry@2.global, (15, Some("wl_seat"), 8)
[1676946581.588693] <- wl_registry@2.global, (16, Some("wp_presentation"), 1)
[1676946581.588714] <- wl_registry@2.global, (17, Some("org_kde_kwin_idle"), 1)
[1676946581.588735] <- wl_registry@2.global, (18, Some("zwlr_layer_shell_v1"), 4)
[1676946581.588762] <- wl_registry@2.global, (19, Some("org_kde_kwin_server_decoration_manager"), 1)
[1676946581.588797] <- wl_registry@2.global, (20, Some("zxdg_decoration_manager_v1"), 1)
[1676946581.588821] <- wl_registry@2.global, (21, Some("zxdg_output_manager_v1"), 3)
[1676946581.588848] <- wl_registry@2.global, (22, Some("zwlr_output_manager_v1"), 4)
[1676946581.588869] <- wl_registry@2.global, (23, Some("zwlr_input_inhibit_manager_v1"), 1)
[1676946581.588897] <- wl_registry@2.global, (24, Some("zwp_keyboard_shortcuts_inhibit_manager_v1"), 1)
[1676946581.588933] <- wl_registry@2.global, (25, Some("zext_workspace_manager_v1"), 1)
[1676946581.588960] <- wl_registry@2.global, (26, Some("zwp_pointer_constraints_v1"), 1)
[1676946581.588986] <- wl_registry@2.global, (27, Some("zwp_relative_pointer_manager_v1"), 1)
[1676946581.589014] <- wl_registry@2.global, (28, Some("zwp_virtual_keyboard_manager_v1"), 1)
[1676946581.589048] <- wl_registry@2.global, (29, Some("zwlr_virtual_pointer_manager_v1"), 2)
[1676946581.589080] <- wl_registry@2.global, (30, Some("zwlr_foreign_toplevel_manager_v1"), 3)
[1676946581.589107] <- wl_registry@2.global, (31, Some("wp_drm_lease_device_v1"), 1)
[1676946581.589132] <- wl_registry@2.global, (32, Some("zwp_tablet_manager_v2"), 1)
[1676946581.589152] <- wl_registry@2.global, (33, Some("zwp_idle_inhibit_manager_v1"), 1)
[1676946581.589179] <- wl_registry@2.global, (34, Some("zxdg_exporter_v1"), 1)
[1676946581.589200] <- wl_registry@2.global, (35, Some("zxdg_importer_v1"), 1)
[1676946581.589220] <- wl_registry@2.global, (36, Some("zxdg_exporter_v2"), 1)
[1676946581.589243] <- wl_registry@2.global, (37, Some("zxdg_importer_v2"), 1)
[1676946581.589262] <- wl_registry@2.global, (38, Some("zwp_pointer_gestures_v1"), 3)
[1676946581.589286] <- wl_registry@2.global, (39, Some("zwp_text_input_manager_v3"), 1)
[1676946581.589309] <- wl_registry@2.global, (40, Some("zwp_input_method_manager_v2"), 1)
[1676946581.589342] <- wl_registry@2.global, (41, Some("xdg_activation_v1"), 1)
[1676946581.589367] <- wl_registry@2.global, (42, Some("xwayland_shell_v1"), 1)
[1676946581.589389] <- wl_registry@2.global, (43, Some("hyprland_toplevel_export_manager_v1"), 2)
[1676946581.589421] <- wl_registry@2.global, (44, Some("wp_fractional_scale_manager_v1"), 1)
[1676946581.589452] <- wl_registry@2.global, (45, Some("wl_output"), 4)
[1676946581.589468] <- wl_registry@2.global, (46, Some("wl_output"), 4)
[1676946581.589487] <- wl_callback@3.done, (10529)
[1676946581.589494] <- wl_display@1.delete_id, (3)
TRACE [mio::poll] registering with poller
TRACE [mio::poll] registering with poller
TRACE [mio::poll] registering with poller
[1676946581.589697] -> wl_registry@2.bind (1, Some("wl_shm"), 1, wl_shm@3)
[1676946581.589724] -> wl_registry@2.bind (4, Some("wl_compositor"), 5, wl_compositor@4)
[1676946581.589744] -> wl_registry@2.bind (45, Some("wl_output"), 4, wl_output@5)
DEBUG [smithay_client_toolkit::registry] Bound new global [45] wl_output v4
[1676946581.589767] -> wl_registry@2.bind (46, Some("wl_output"), 4, wl_output@6)
DEBUG [smithay_client_toolkit::registry] Bound new global [46] wl_output v4
[1676946581.589790] -> wl_registry@2.bind (21, Some("zxdg_output_manager_v1"), 3, zxdg_output_manager_v1@7)
DEBUG [smithay_client_toolkit::registry] Bound new global [21] zxdg_output_manager_v1 v3
[1676946581.589822] -> zxdg_output_manager_v1@7.get_xdg_output (zxdg_output_v1@8, wl_output@5)
[1676946581.589836] -> zxdg_output_manager_v1@7.get_xdg_output (zxdg_output_v1@9, wl_output@6)
[1676946581.589847] -> wl_registry@2.bind (18, Some("zwlr_layer_shell_v1"), 4, zwlr_layer_shell_v1@10)
[1676946581.589943] <- wl_shm@3.format, (0)
[1676946581.589950] <- wl_shm@3.format, (1)
[1676946581.589957] <- wl_shm@3.format, (875709016)
[1676946581.589966] <- wl_shm@3.format, (875708993)
[1676946581.589974] <- wl_shm@3.format, (875710274)
[1676946581.589983] <- wl_shm@3.format, (842094674)
[1676946581.589992] <- wl_shm@3.format, (842088786)
[1676946581.590001] <- wl_shm@3.format, (892426322)
[1676946581.590007] <- wl_shm@3.format, (892420434)
[1676946581.590014] <- wl_shm@3.format, (909199186)
[1676946581.590023] <- wl_shm@3.format, (808665688)
[1676946581.590031] <- wl_shm@3.format, (808665665)
[1676946581.590039] <- wl_shm@3.format, (1211384408)
[1676946581.590048] <- wl_shm@3.format, (1211384385)
[1676946581.590056] <- wl_shm@3.format, (942948952)
[1676946581.590064] <- wl_shm@3.format, (942948929)
[1676946581.590073] <- wl_output@5.geometry, (0, 0, 340, 220, 0, Some("BOE"), Some("0x0997"), 0)
[1676946581.590103] <- wl_output@5.mode, (1, 2560, 1600, 120000)
[1676946581.590121] <- wl_output@5.scale, (2)
[1676946581.590129] <- wl_output@5.name, (Some("eDP-1"))
[1676946581.590141] <- wl_output@5.description, (Some("BOE 0x0997 (eDP-1)"))
[1676946581.590157] <- wl_output@5.done, ()
[1676946581.590163] <- wl_output@6.geometry, (0, 0, 800, 330, 0, Some("Huawei Technologies Co., Inc."), Some("ZQE-CAA"), 0)
[1676946581.590198] <- wl_output@6.mode, (1, 3440, 1440, 120000)
[1676946581.590209] <- wl_output@6.scale, (1)
[1676946581.590217] <- wl_output@6.name, (Some("DP-1"))
[1676946581.590228] <- wl_output@6.description, (Some("Huawei Technologies Co., Inc. ZQE-CAA 0x0000F622 (DP-1)"))
[1676946581.590267] <- wl_output@6.done, ()
[1676946581.590275] <- zxdg_output_v1@8.name, (Some("eDP-1"))
[1676946581.590288] <- zxdg_output_v1@8.description, (Some("BOE 0x0997 (eDP-1)"))
[1676946581.590307] <- zxdg_output_v1@8.logical_position, (700, 1440)
[1676946581.590315] <- zxdg_output_v1@8.logical_size, (2133, 1333)
[1676946581.590325] <- wl_output@5.done, ()
[1676946581.590335] <- zxdg_output_v1@9.name, (Some("DP-1"))
[1676946581.590349] <- zxdg_output_v1@9.description, (Some("Huawei Technologies Co., Inc. ZQE-CAA 0x0000F622 (DP-1)"))
[1676946581.590387] <- zxdg_output_v1@9.logical_position, (0, 0)
[1676946581.590403] <- zxdg_output_v1@9.logical_size, (3440, 1440)
[1676946581.590412] <- wl_output@6.done, ()
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Argb8888
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Xrgb8888
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Xbgr8888
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Abgr8888
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Bgr888
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Rgbx4444
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Rgba4444
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Rgbx5551
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Rgba5551
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Rgb565
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Xbgr2101010
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Abgr2101010
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Xbgr16161616f
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Abgr16161616f
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Xbgr16161616
DEBUG [smithay_client_toolkit::shm] supported wl_shm format Abgr16161616
[1676946581.590475] -> wl_compositor@4.create_surface (wl_surface@11)
[1676946581.590485] -> wl_surface@11.set_buffer_scale (2)
[1676946581.590500] -> zwlr_layer_shell_v1@10.get_layer_surface (zwlr_layer_surface_v1@12, wl_surface@11, wl_output@5, 0, Some("wpaperd-eDP-1"))
[1676946581.590526] -> zwlr_layer_surface_v1@12.set_size (0, 0)
[1676946581.590542] -> zwlr_layer_surface_v1@12.set_anchor (15)
[1676946581.590552] -> zwlr_layer_surface_v1@12.set_exclusive_zone (-1)
[1676946581.590560] -> wl_surface@11.commit ()
[1676946581.590568] -> wl_surface@11.commit ()
[1676946581.590585] -> wl_shm@3.create_pool (wl_shm_pool@13, 11, 1200)
[1676946581.590609] -> wl_compositor@4.create_surface (wl_surface@14)
[1676946581.590623] -> wl_surface@14.set_buffer_scale (1)
[1676946581.590632] -> zwlr_layer_shell_v1@10.get_layer_surface (zwlr_layer_surface_v1@15, wl_surface@14, wl_output@6, 0, Some("wpaperd-DP-1"))
[1676946581.590658] -> zwlr_layer_surface_v1@15.set_size (0, 0)
[1676946581.590668] -> zwlr_layer_surface_v1@15.set_anchor (15)
[1676946581.590675] -> zwlr_layer_surface_v1@15.set_exclusive_zone (-1)
[1676946581.590684] -> wl_surface@14.commit ()
[1676946581.590694] -> wl_surface@14.commit ()
[1676946581.590703] -> wl_shm@3.create_pool (wl_shm_pool@16, 13, 1200)
[1676946581.591031] <- zwlr_layer_surface_v1@12.configure, (10530, 2133, 1333)
[1676946581.591048] <- zwlr_layer_surface_v1@15.configure, (10531, 3440, 1440)
[1676946581.591065] -> zwlr_layer_surface_v1@12.ack_configure (10530)
[1676946581.591077] -> zwlr_layer_surface_v1@15.ack_configure (10531)
[1676946581.591091] -> wl_shm_pool@13.resize (45492624)
[1676946581.591114] -> wl_shm_pool@13.resize (90985248)
[1676946581.591128] -> wl_shm_pool@13.create_buffer (wl_buffer@17, 0, 4266, 2666, 17064, 875708993)
[1676946582.360279] -> wl_surface@11.attach (wl_buffer@17, 0, 0)
[1676946582.360301] -> wl_surface@11.damage_buffer (0, 0, 4266, 2666)
[1676946582.360309] -> wl_surface@11.commit ()
[1676946582.360320] -> wl_buffer@17.destroy ()
[1676946582.360339] -> wl_shm_pool@16.resize (19814400)
[1676946582.360365] -> wl_shm_pool@16.create_buffer (wl_buffer@18, 0, 3440, 1440, 13760, 875708993)
[1676946582.978047] -> wl_surface@14.attach (wl_buffer@18, 0, 0)
[1676946582.978075] -> wl_surface@14.damage_buffer (0, 0, 3440, 1440)
[1676946582.978086] -> wl_surface@14.commit ()
[1676946582.978092] -> wl_buffer@18.destroy ()
[1676946582.998812] <- zwlr_layer_surface_v1@12.configure, (10532, 2133, 1333)
[1676946582.998842] <- wl_surface@11.enter, (wl_output@5)
[1676946582.998855] <- wl_buffer@17.release, ()
[1676946582.998864] <- wl_display@1.delete_id, (17)
[1676946582.998880] <- zwlr_layer_surface_v1@15.configure, (10533, 3440, 1440)
[1676946582.998894] <- wl_surface@14.enter, (wl_output@6)
[1676946582.998910] <- wl_buffer@18.release, ()
[1676946582.998921] <- wl_display@1.delete_id, (18)
[1676946582.998951] -> zwlr_layer_surface_v1@12.ack_configure (10532)
[1676946582.998970] -> zwlr_layer_surface_v1@15.ack_configure (10533)
```
</details>