### PR TITLE
Add 'ascending' and 'descending' sorting options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,15 @@ the config file. This is an example configuration:
 [default]
 path = "/home/danyspin97/Pictures/Wallpapers/"
 duration = "30m"
+sorting = "random"
 
 [eDP-1]
 path = "/home/danyspin97/Pictures/Wallpapers/github_octupus.png"
 apply-shadow = true
+
+[DP-2]
+path = "/home/danyspin97/Pictures/Landscapes/"
+sorting = "reverse"
 ```
 
 If you're running sway, you can look for the available outputs and their ID by running:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ represents a different output and contains the following keys:
   This is only valid when path points to a directory. (_Optional_)
 - `apply-shadow`, apply a shadow on the top part of the image, to work as a shadow effect
   of the status bar. This is particularly suited for window managers like sway. (_Optional_)
+- `sorting`, choose the sorting order. Valid options are `Natural`, `Reverse`, and `Random`,
+  with the unspecified or default being `Random` (_Optional_)
 
 The section `default` will be used as fallback for the all the outputs that aren't listed in
 the config file. This is an example configuration:
@@ -107,7 +109,7 @@ the config file. This is an example configuration:
 [default]
 path = "/home/danyspin97/Pictures/Wallpapers/"
 duration = "30m"
-sorting = "random"
+sorting = "Natural"
 
 [eDP-1]
 path = "/home/danyspin97/Pictures/Wallpapers/github_octupus.png"
@@ -115,7 +117,7 @@ apply-shadow = true
 
 [DP-2]
 path = "/home/danyspin97/Pictures/Landscapes/"
-sorting = "reverse"
+sorting = "Reverse"
 ```
 
 If you're running sway, you can look for the available outputs and their ID by running:

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ represents a different output and contains the following keys:
   This is only valid when path points to a directory. (_Optional_)
 - `apply-shadow`, apply a shadow on the top part of the image, to work as a shadow effect
   of the status bar. This is particularly suited for window managers like sway. (_Optional_)
-- `sorting`, choose the sorting order. Valid options are `Natural`, `Reverse`, and `Random`,
-  with the unspecified or default being `Random` (_Optional_)
+- `sorting`, choose the sorting order. Valid options are `ascending`, `descending`, and `random`,
+  with the unspecified or default being `random` (_Optional_)
 
 The section `default` will be used as fallback for the all the outputs that aren't listed in
 the config file. This is an example configuration:
@@ -109,7 +109,7 @@ the config file. This is an example configuration:
 [default]
 path = "/home/danyspin97/Pictures/Wallpapers/"
 duration = "30m"
-sorting = "Natural"
+sorting = "ascending"
 
 [eDP-1]
 path = "/home/danyspin97/Pictures/Wallpapers/github_octupus.png"
@@ -117,7 +117,7 @@ apply-shadow = true
 
 [DP-2]
 path = "/home/danyspin97/Pictures/Landscapes/"
-sorting = "Reverse"
+sorting = "descending"
 ```
 
 If you're running sway, you can look for the available outputs and their ID by running:

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -222,13 +222,13 @@ impl Surface {
                     Sorting::Random => {
                         let index = rand::random::<usize>() % files.len();
                         files.into_iter().nth(index).unwrap()
-                      }
-                    Sorting::Natural => {
+                    },
+                    Sorting::Ascending => {
                         let mut sorted = files;
                         sorted.sort();
                         sorted.remove(self.idx)
                     },
-                    Sorting::Reverse => {
+                    Sorting::Descending => {
                         let mut sorted = files;
                         sorted.sort_by(|a,b| b.cmp(a));
                         sorted.remove(self.idx)

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -220,17 +220,18 @@ impl Surface {
                 // than reading paths off the disk, right?
                 let img_path = match self.wallpaper_info.sorting {
                     Sorting::Random => {
-                        files[rand::random::<usize>() % files.len()].clone()
+                        let index = rand::random::<usize>() % files.len();
+                        files.into_iter().nth(index).unwrap()
                       }
                     Sorting::Natural => {
                         let mut sorted = files;
                         sorted.sort();
-                        sorted[self.idx].clone()
+                        sorted.remove(self.idx)
                     },
                     Sorting::Reverse => {
                         let mut sorted = files;
                         sorted.sort_by(|a,b| b.cmp(a));
-                        sorted[self.idx].clone()
+                        sorted.remove(self.idx)
                     },
                 };
 

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -216,17 +216,19 @@ impl Surface {
                     },
                     Sorting::Ascending => {
                         let idx = match files.binary_search(&self.current_img) {
-                            Ok(n) => n,
+			    // Perform increment here, do validation/bounds checking below
+                            Ok(n) => n+1,
                             Err(err) => {
                                 info!("Current image not found, defaulting to first image ({:?})", err);
                                 // set idx to > slice length so the guard sets it correctly for us
                                 files.len()
                             }
                         };
+
                         if idx >= files.len() {
                             0
                         } else {
-                            idx + 1
+                            idx
                         }
                     },
                     Sorting::Descending => {
@@ -237,6 +239,8 @@ impl Surface {
                                 files.len()
                             }
                         };
+
+			// Here, bounds checking is strictly ==, as we cannot go lower than 0 for usize
                         if idx == 0 {
                             files.len()-1
                         } else {
@@ -245,8 +249,9 @@ impl Surface {
                     },
                 };
 
+
                 // Actually grab the image with our new index
-                let img_path = files.into_iter().nth(index).unwrap();
+		let img_path = files[index].clone();
 
                 match open(&img_path).with_context(|| format!("opening the image {img_path:?}")) {
                     Ok(image) => {

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -20,6 +20,7 @@ use smithay_client_toolkit::shm::slot::SlotPool;
 use walkdir::WalkDir;
 
 use crate::wallpaper_info::WallpaperInfo;
+use crate::wallpaper_info::Sorting;
 use crate::wpaperd::Wpaperd;
 
 pub struct Surface {
@@ -217,18 +218,20 @@ impl Surface {
                 // This is a bit unweildy. We're sorting every time thru this loop. But since we're
                 // walking the directory each time, I guess it's not that bad. Sorting can't be slower
                 // than reading paths off the disk, right?
-                let img_path = if self.wallpaper_info.sorting.eq(&Some(String::from("natural"))) {
-                    // You can't sort an immutable Vec, so we have to clone it as mutable.
-                    let mut sorted: Vec<PathBuf> = files.clone();
-                    sorted.sort();
-                    sorted[self.idx].clone()
-                } else if self.wallpaper_info.sorting.eq(&Some(String::from("reverse"))) {
-                    // You can't sort an immutable Vec, so we have to clone it as mutable.
-                    let mut reversed: Vec<PathBuf> = files.clone();
-                    reversed.sort_by(|a,b| b.cmp(a));
-                    reversed[self.idx].clone()
-                } else {
-                    files[rand::random::<usize>() % files.len()].clone()
+                let img_path = match self.wallpaper_info.sorting {
+                    Sorting::Random => {
+                        files[rand::random::<usize>() % files.len()].clone()
+                      }
+                    Sorting::Natural => {
+                        let mut sorted = files;
+                        sorted.sort();
+                        sorted[self.idx].clone()
+                    },
+                    Sorting::Reverse => {
+                        let mut sorted = files;
+                        sorted.sort_by(|a,b| b.cmp(a));
+                        sorted[self.idx].clone()
+                    },
                 };
 
                 match open(&img_path).with_context(|| format!("opening the image {img_path:?}")) {

--- a/daemon/src/wallpaper_info.rs
+++ b/daemon/src/wallpaper_info.rs
@@ -17,13 +17,11 @@ pub struct WallpaperInfo {
 }
 
 #[derive(Debug, Copy, Clone, Default, Eq, PartialEq,Deserialize)]
+#[serde(rename_all="lowercase")]
 pub enum Sorting {
     #[default]
-    #[serde(alias="Random", alias="random", alias="RANDOM")]
     Random,
-    #[serde(alias="Ascending", alias="ascending", alias="ASCENDING")]
     Ascending,
-    #[serde(alias="Descending", alias="descending", alias="DESCENDING")]
     Descending,
 }
 

--- a/daemon/src/wallpaper_info.rs
+++ b/daemon/src/wallpaper_info.rs
@@ -12,6 +12,8 @@ pub struct WallpaperInfo {
     pub duration: Option<Duration>,
     #[serde(rename = "apply-shadow")]
     pub apply_shadow: Option<bool>,
+    #[serde(default = "set_sorting_default", deserialize_with = "order_deserializer")]
+    pub sorting: Option<String>
 }
 
 pub fn tilde_expansion_deserialize<'de, D>(deserializer: D) -> Result<Option<PathBuf>, D::Error>
@@ -25,4 +27,29 @@ where
         path.strip_prefix("~")
             .map_or(path.to_path_buf(), |p| home_dir().unwrap().join(p)),
     ))
+}
+
+fn set_sorting_default() -> Option<String> {
+    Some("random".to_string())
+}
+
+pub fn order_deserializer<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let natural = String::from("natural");
+    let reverse = String::from("reverse");
+    let random = String::from("random");
+    let order = String::deserialize(deserializer)?;
+
+    // Default to random sorting if we don't match reverse or natural
+    let result = if order.eq(&reverse) {
+        reverse
+    } else if order.eq(&natural) {
+        natural
+    } else {
+        random
+    };
+
+    Ok(Some(result))
 }

--- a/daemon/src/wallpaper_info.rs
+++ b/daemon/src/wallpaper_info.rs
@@ -12,8 +12,17 @@ pub struct WallpaperInfo {
     pub duration: Option<Duration>,
     #[serde(rename = "apply-shadow")]
     pub apply_shadow: Option<bool>,
-    #[serde(default = "set_sorting_default", deserialize_with = "order_deserializer")]
-    pub sorting: Option<String>
+    #[serde(default)]
+    pub sorting: Sorting,
+}
+
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq,Deserialize)]
+#[serde(rename = "kebab-case")]
+pub enum Sorting {
+    #[default]
+    Random,
+    Natural,
+    Reverse,
 }
 
 pub fn tilde_expansion_deserialize<'de, D>(deserializer: D) -> Result<Option<PathBuf>, D::Error>
@@ -27,29 +36,4 @@ where
         path.strip_prefix("~")
             .map_or(path.to_path_buf(), |p| home_dir().unwrap().join(p)),
     ))
-}
-
-fn set_sorting_default() -> Option<String> {
-    Some("random".to_string())
-}
-
-pub fn order_deserializer<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let natural = String::from("natural");
-    let reverse = String::from("reverse");
-    let random = String::from("random");
-    let order = String::deserialize(deserializer)?;
-
-    // Default to random sorting if we don't match reverse or natural
-    let result = if order.eq(&reverse) {
-        reverse
-    } else if order.eq(&natural) {
-        natural
-    } else {
-        random
-    };
-
-    Ok(Some(result))
 }

--- a/daemon/src/wallpaper_info.rs
+++ b/daemon/src/wallpaper_info.rs
@@ -17,12 +17,14 @@ pub struct WallpaperInfo {
 }
 
 #[derive(Debug, Copy, Clone, Default, Eq, PartialEq,Deserialize)]
-#[serde(rename = "kebab-case")]
 pub enum Sorting {
     #[default]
+    #[serde(alias="Random", alias="random", alias="RANDOM")]
     Random,
-    Natural,
-    Reverse,
+    #[serde(alias="Ascending", alias="ascending", alias="ASCENDING")]
+    Ascending,
+    #[serde(alias="Descending", alias="descending", alias="DESCENDING")]
+    Descending,
 }
 
 pub fn tilde_expansion_deserialize<'de, D>(deserializer: D) -> Result<Option<PathBuf>, D::Error>

--- a/man/wpaperd-output.5.scd
+++ b/man/wpaperd-output.5.scd
@@ -28,6 +28,8 @@ The valid keys for the section are the following:
 - *path*, path to the image/directory
 - *duration*, how much time the image should be displayed until it is changed with a new one.
   This is only valid when path points to a directory. (_Optional_)
+- *sorting*, choose the sorting order. Valid options are `ascending`, `descending`, and `random`,
+  with the unspecified or default being `random` (_Optional_)
 
 ## DEFAULT SECTION
 
@@ -40,9 +42,15 @@ outputs not listed in this configuration file.
 [default]
 path = "/home/danyspin97/Pictures/Wallpapers/"
 duration = "30m"
+sorting = "ascending"
 
 [eDP-1]
 path = "/home/danyspin97/Pictures/Wallpapers/github_octupus.png"
+apply-shadow = true
+
+[DP-2]
+path = "/home/danyspin97/Pictures/Landscapes/"
+sorting = "descending"
 ```
 
 # AUTHOR


### PR DESCRIPTION
This is an attempt to handle #5. 

I'm very new to rust, so I know there's some... not-idiomatic rust in here, and I'm happy to get some feedback on how it can be made better, or if I've missed something.

This let's you specify how you want the sorting handled,  either random (the default), ascending, or descending:

```toml
[default]
path = "/path/to/papers"
sorting = "ascending"

[eDP-1]
path = "/path/to/other/papers"
duration = "1m"
sorting = "descending"

[DP-2]
path = "/path/to/even/more"
duration = "5m"
```

That configuration would use a different sort for each monitor, a missing `sorting` value defaults to `random`.

Edit: Updated PR message to use the new sorting names.

Hoping to get some good feedback to make this PR better!