### PR TITLE
Add reload config ability

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,6 +20,7 @@ enum SubCmd {
     AllWallpapers,
     NextWallpaper { monitors: Vec<String> },
     PreviousWallpaper { monitors: Vec<String> },
+    ReloadConfig,
 }
 
 fn main() {
@@ -31,6 +32,7 @@ fn main() {
         SubCmd::AllWallpapers => IpcMessage::AllWallpapers,
         SubCmd::NextWallpaper { monitors } => IpcMessage::NextWallpaper { monitors },
         SubCmd::PreviousWallpaper { monitors } => IpcMessage::PreviousWallpaper { monitors },
+        SubCmd::ReloadConfig => IpcMessage::ReloadConfig,
     };
     conn.write_all(&serde_json::to_vec(&msg).unwrap()).unwrap();
     // Add a new line after the message

--- a/daemon/src/ipc_server.rs
+++ b/daemon/src/ipc_server.rs
@@ -120,6 +120,11 @@ fn handle_message(buffer: &mut String, ustream: UnixStream, wpaperd: &mut Wpaper
 
             IpcResponse::Ok
         }),
+
+        IpcMessage::ReloadConfig => {
+            wpaperd.reload_config()?;
+            Ok(IpcResponse::Ok)
+        }
     };
 
     let mut stream = BufWriter::new(ustream);

--- a/daemon/src/wallpaper_config.rs
+++ b/daemon/src/wallpaper_config.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use crate::wallpaper_info::WallpaperInfo;
 
-#[derive(Deserialize, PartialEq)]
+#[derive(Deserialize)]
 pub struct WallpaperConfig {
     #[serde(flatten)]
     data: HashMap<String, Arc<WallpaperInfo>>,
@@ -51,5 +51,11 @@ Either remove `duration` or set `path` to a directory"
 
     pub fn get_output_by_name(&self, name: &str) -> Arc<WallpaperInfo> {
         self.data.get(name).unwrap_or(&self.default_config).clone()
+    }
+}
+
+impl PartialEq for WallpaperConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
     }
 }

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -9,6 +9,7 @@ pub enum IpcMessage {
     NextWallpaper { monitors: Vec<String> },
     PreviousWallpaper { monitors: Vec<String> },
     AllWallpapers,
+    ReloadConfig,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
This PR implements a new IPC command to force wpaperd to reload config. The original proposal for this PR is that the file watcher does not watch the symlink content change, so if the config is symlinked to another file, wpaperd will never know the config has changed.