### PR TITLE
feat: user can disable the first wallpaper transition

### DIFF
--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -38,6 +38,13 @@ pub struct SerializedWallpaperInfo {
     pub mode: Option<BackgroundMode>,
     pub queue_size: Option<usize>,
     pub transition_time: Option<u32>,
+    
+    /// Determines if we should show the transition between black and first 
+    /// wallpaper. `Some(false)` means we instantly cut to the first wallpaper,
+    /// `Some(true)` means we fade from black to the first wallpaper.
+    ///
+    /// See [crate::wallpaper_info::WallpaperInfo]
+    pub initial_transition: Option<bool>,
 }
 
 impl SerializedWallpaperInfo {
@@ -126,6 +133,10 @@ impl SerializedWallpaperInfo {
             (Some(transition_time), _) | (None, Some(transition_time)) => *transition_time,
             (None, None) => Renderer::DEFAULT_TRANSITION_TIME,
         };
+        let initial_transition = match (&self.initial_transition, &default.initial_transition) {
+            (Some(initial_transition), _) | (None, Some(initial_transition)) => *initial_transition,
+            (None, None) => true,
+        };
 
         Ok(WallpaperInfo {
             path,
@@ -135,6 +146,7 @@ impl SerializedWallpaperInfo {
             mode,
             drawn_images_queue_size,
             transition_time,
+            initial_transition
         })
     }
 }

--- a/daemon/src/render/renderer.rs
+++ b/daemon/src/render/renderer.rs
@@ -256,8 +256,9 @@ impl Renderer {
     }
 
     #[inline]
-    pub fn start_transition(&mut self, time: u32) {
+    pub fn start_transition(&mut self, time: u32, new_transition_time: u32) {
         self.time_started = time;
+        self.transition_time = new_transition_time;
         self.transition_fit_changed = false;
     }
 

--- a/daemon/src/wallpaper_info.rs
+++ b/daemon/src/wallpaper_info.rs
@@ -13,6 +13,11 @@ pub struct WallpaperInfo {
     pub mode: BackgroundMode,
     pub drawn_images_queue_size: usize,
     pub transition_time: u32,
+
+    /// Determines if we should show the transition between black and first 
+    /// wallpaper. `false` means we instantly cut to the first wallpaper,
+    /// `true` means we fade from black to the first wallpaper.
+    pub initial_transition: bool,
 }
 
 impl Default for WallpaperInfo {
@@ -25,6 +30,7 @@ impl Default for WallpaperInfo {
             mode: BackgroundMode::default(),
             drawn_images_queue_size: ImagePicker::DEFAULT_DRAWN_IMAGES_QUEUE_SIZE,
             transition_time: Renderer::DEFAULT_TRANSITION_TIME,
+            initial_transition: true,
         }
     }
 }

--- a/man/wpaperd-output.5.scd
+++ b/man/wpaperd-output.5.scd
@@ -50,6 +50,8 @@ represents a different display and can contain the following keys:
 - `transition_time`, how many milliseconds should the transition run. (_Optional_, `300` by default).
 - `queue_size`, decide how big the queue should be when `path` is set a directory and `sorting` is
    set to `random`. (_Optional_, `10` by default)
+- `initial_transition`, whether or not to transition from the initial black screen (_Optional_, `true` by default)
+  
 
 ## DEFAULT SECTION
 


### PR DESCRIPTION
Optionally removes the initial transition from black screen via `initial_transition` configuration option.

<details><summary>no initial transition config</summary>

```toml
# config.toml
[eDP-1]
path = "/home/micycle/Downloads/wallpapers/"
duration = "5s"
transition_time = 2000
initial_transition = false
```

</details>

[no_initial_transition.webm](https://github.com/danyspin97/wpaperd/assets/29179327/d889c36b-c361-4640-9e31-d89d03a6f0c8)

<details><summary>initial transition config</summary>

```toml
# config.toml
[eDP-1]
path = "/home/micycle/Downloads/wallpapers/"
duration = "5s"
transition_time = 2000
initial_transition = true # the default
```

</details>

[initial_transition.webm](https://github.com/danyspin97/wpaperd/assets/29179327/3e66cd5d-6baf-4902-8e88-d24a53816073)
