### PR TITLE
wip: wpaperctl set MONITOR NEW_WP_PATH

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,6 +29,9 @@ fn main() {
         SubCmd::ReloadWallpaper { monitors } => IpcMessage::ReloadWallpaper { monitors },
         SubCmd::PauseWallpaper { monitors } => IpcMessage::PauseWallpaper { monitors },
         SubCmd::ResumeWallpaper { monitors } => IpcMessage::ResumeWallpaper { monitors },
+        SubCmd::SetWallaper { monitor, wallpaper } => {
+            IpcMessage::SetWallpaper { monitor, wallpaper }
+        }
     };
     conn.write_all(&serde_json::to_vec(&msg).unwrap()).unwrap();
     let mut buf = String::new();
@@ -37,7 +40,7 @@ fn main() {
         serde_json::from_str(&buf).expect("wpaperd to return a valid json");
     match res {
         Ok(resp) => match resp {
-            IpcResponse::CurrentWallpaper { path } => println!("{}", path.to_string_lossy()),
+            IpcResponse::CurrentWallpaper { path } => println!("{}", path.display()),
             IpcResponse::AllWallpapers { entries: paths } => {
                 if json_resp {
                     #[derive(Serialize)]

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -26,4 +26,10 @@ pub enum SubCmd {
     PauseWallpaper { monitors: Vec<String> },
     #[clap(visible_alias = "resume")]
     ResumeWallpaper { monitors: Vec<String> },
+
+    #[clap(visible_alias = "set")]
+    SetWallaper {
+        monitor: String,
+        wallpaper: std::path::PathBuf,
+    },
 }

--- a/daemon/src/ipc_server.rs
+++ b/daemon/src/ipc_server.rs
@@ -29,7 +29,7 @@ pub fn listen_on_ipc_socket(socket_path: &Path) -> Result<SocketSource> {
     Ok(socket)
 }
 
-fn check_monitors(wpaperd: &Wpaperd, monitors: &Vec<String>) -> Result<(), IpcError> {
+fn check_monitors(wpaperd: &Wpaperd, monitors: &[String]) -> Result<(), IpcError> {
     for monitor in monitors {
         if !wpaperd
             .surfaces
@@ -146,6 +146,18 @@ pub fn handle_message(
             }
             IpcResponse::Ok
         }),
+
+        IpcMessage::SetWallpaper { monitor, wallpaper } => {
+            dbg!("SetWallpaper");
+            let monitors = vec![monitor];
+            check_monitors(wpaperd, &monitors).map(|_| {
+                for surf in collect_surfaces(wpaperd, monitors).iter_mut() {
+                    surf.set_new_wallpaper_path(wallpaper.as_path());
+                    surf.draw(&qh, 1_000).unwrap(); //TODO: should draw take an Option<'time'>?
+                }
+                IpcResponse::Ok
+            })
+        }
     };
 
     let mut stream = BufWriter::new(ustream);

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    path::PathBuf,
+    path::{Path, PathBuf},
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -400,6 +400,10 @@ impl Surface {
             self.renderer
                 .update_transition_time(self.wallpaper_info.transition_time);
         }
+    }
+
+    pub fn set_new_wallpaper_path(&mut self, new_path: &Path) {
+        self.wallpaper_info.path = new_path.to_path_buf();
     }
 
     /// Add a new timer in the event_loop for the current duration

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -12,6 +12,7 @@ pub enum IpcMessage {
     ResumeWallpaper { monitors: Vec<String> },
     AllWallpapers,
     ReloadWallpaper { monitors: Vec<String> },
+    SetWallpaper { monitor: String, wallpaper: PathBuf },
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
Heya,

I have [a tool that pulls new images for me every 10 minutes](https://github.com/alphastrata/rustwari) from a server, I don't like my current solution which is a shell script modifying the `~./config...`'s path on a per monitor basis.
I think it'd be nice to be able to do something like:
`wpaperctl set <MONITOR> <NEW_WALLPAPER_PATH>` kinda thing..

I've gotten _most_ of the way there in this PR, but wanted to get thoughts etc before finishing it, as I'm certainly missing something.

Also, I get:
 ```sh
cargo run --bin wpaperd -- -d
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/wpaperd -d`
target/debug/wpaperd: error while loading shared libraries: libEGL.so.1: cannot open shared object file: No such file or directory
``` which is _weird_? as I'm using the included flake.



