### PR TITLE
feat: toggle pause state of auto wallpaper sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,18 @@ $ wpaperctl next
 $ wpaperctl previous
 ```
 
-When `sorting` is set to `asceding` and `desceding`, _wpaperd_ will use the wallpaper name to
+When `sorting` is set to `ascending` and `descending`, _wpaperd_ will use the wallpaper name to
 calculate the next wallpaper accordingly. When `sorting` is set to `random`, it will store
 all the wallpapers shown in a queue, so that the commands `next` and `previous` can work
 as intended.
+
+The cycling of images can also be paused/resumed by running the `pause` and `resume` commands, or just `toggle-pause`, using _wpaperctl_:
+
+```bash
+$ wpaperctl pause
+$ wpaperctl resume
+$ wpaperctl toggle-pause
+```
 
 ## Wallpaper Configuration
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,6 +29,7 @@ fn main() {
         SubCmd::ReloadWallpaper { monitors } => IpcMessage::ReloadWallpaper { monitors },
         SubCmd::PauseWallpaper { monitors } => IpcMessage::PauseWallpaper { monitors },
         SubCmd::ResumeWallpaper { monitors } => IpcMessage::ResumeWallpaper { monitors },
+        SubCmd::TogglePauseWallpaper { monitors } => IpcMessage::TogglePauseWallpaper { monitors },
     };
     conn.write_all(&serde_json::to_vec(&msg).unwrap()).unwrap();
     let mut buf = String::new();

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -26,4 +26,6 @@ pub enum SubCmd {
     PauseWallpaper { monitors: Vec<String> },
     #[clap(visible_alias = "resume")]
     ResumeWallpaper { monitors: Vec<String> },
+    #[clap(visible_alias = "toggle-pause")]
+    TogglePauseWallpaper { monitors: Vec<String> },
 }

--- a/daemon/src/ipc_server.rs
+++ b/daemon/src/ipc_server.rs
@@ -146,6 +146,24 @@ pub fn handle_message(
             }
             IpcResponse::Ok
         }),
+
+        IpcMessage::TogglePauseWallpaper { monitors } => {
+            check_monitors(wpaperd, &monitors).map(|_| {
+                let surfaces = collect_surfaces(wpaperd, monitors);
+                if surfaces.is_empty() {
+                    return IpcResponse::Ok;
+                }
+
+                // Ensure synced pause state for the provided surfaces
+                if surfaces[0].should_pause() {
+                    surfaces.into_iter().for_each(|s| s.resume());
+                } else {
+                    surfaces.into_iter().for_each(|s| s.pause());
+                };
+
+                IpcResponse::Ok
+            })
+        }
     };
 
     let mut stream = BufWriter::new(ustream);

--- a/daemon/src/ipc_server.rs
+++ b/daemon/src/ipc_server.rs
@@ -149,17 +149,9 @@ pub fn handle_message(
 
         IpcMessage::TogglePauseWallpaper { monitors } => {
             check_monitors(wpaperd, &monitors).map(|_| {
-                let surfaces = collect_surfaces(wpaperd, monitors);
-                if surfaces.is_empty() {
-                    return IpcResponse::Ok;
+                for surface in collect_surfaces(wpaperd, monitors) {
+                    surface.toggle_pause();
                 }
-
-                // Ensure synced pause state for the provided surfaces
-                if surfaces[0].should_pause() {
-                    surfaces.into_iter().for_each(|s| s.resume());
-                } else {
-                    surfaces.into_iter().for_each(|s| s.pause());
-                };
 
                 IpcResponse::Ok
             })

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -513,6 +513,13 @@ impl Surface {
     pub fn resume(&mut self) {
         self.should_pause = false;
     }
+
+    /// Returns a boolean representing whether this [`Surface`] is set to indicate to the main event
+    /// loop that its automatic wallpaper sequence should be paused.
+    #[inline]
+    pub fn should_pause(&self) -> bool {
+        self.should_pause
+    }
 }
 
 fn black_image() -> RgbaImage {

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -514,6 +514,18 @@ impl Surface {
         self.should_pause = false;
     }
 
+    /// Toggle the pause state for this [`Surface`], which is responsible for indicating to the main
+    /// event loop that the automatic wallpaper sequence should be paused.
+    /// The actual pausing/resuming is handled in [`Surface::handle_pause_state`]
+    #[inline]
+    pub fn toggle_pause(&mut self) {
+        if self.should_pause() {
+            self.resume();
+        } else {
+            self.pause();
+        };
+    }
+
     /// Returns a boolean representing whether this [`Surface`] is set to indicate to the main event
     /// loop that its automatic wallpaper sequence should be paused.
     #[inline]

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -10,6 +10,7 @@ pub enum IpcMessage {
     PreviousWallpaper { monitors: Vec<String> },
     PauseWallpaper { monitors: Vec<String> },
     ResumeWallpaper { monitors: Vec<String> },
+    TogglePauseWallpaper { monitors: Vec<String> },
     AllWallpapers,
     ReloadWallpaper { monitors: Vec<String> },
 }


### PR DESCRIPTION
In relation to #48 and continuing from #68

As requested, a quick PR to add a command to simply toggle the pause state, as an alternative to the explicit `pause` and `resume` commands. Happy to make any changes you want so just let me know.

I also added a section to the README but let me know if I should remove that so you can do it yourself for potentially the next release.