### PR TITLE
ensure textures are always destroyed

### DIFF
--- a/daemon/src/render/wallpaper.rs
+++ b/daemon/src/render/wallpaper.rs
@@ -1,4 +1,4 @@
-use std::ffi::CStr;
+use std::{ffi::CStr, rc::Rc};
 
 use color_eyre::{
     eyre::{bail, ensure},
@@ -10,43 +10,58 @@ use crate::{gl_check, render::gl};
 
 use super::load_texture;
 
-#[derive(Default)]
 pub struct Wallpaper {
-    pub texture: gl::types::GLuint,
-    pub image_width: u32,
-    pub image_height: u32,
+    gl: Rc<gl::Gl>,
+    texture: gl::types::GLuint,
+    image_width: u32,
+    image_height: u32,
 }
 
 impl Wallpaper {
-    pub const fn new() -> Self {
+    pub const fn new(gl: Rc<gl::Gl>) -> Self {
         Self {
+            gl,
             texture: 0,
             image_width: 10,
             image_height: 10,
         }
     }
 
-    pub fn bind(&self, gl: &gl::Gl) -> Result<()> {
+    pub fn bind(&self) -> Result<()> {
         unsafe {
-            gl.BindTexture(gl::TEXTURE_2D, self.texture);
-            gl_check!(gl, "binding textures");
+            self.gl.BindTexture(gl::TEXTURE_2D, self.texture);
+            gl_check!(self.gl, "binding textures");
         }
 
         Ok(())
     }
 
-    pub fn load_image(&mut self, gl: &gl::Gl, image: DynamicImage) -> Result<()> {
+    pub fn load_image(&mut self, image: DynamicImage) -> Result<()> {
         self.image_width = image.width();
         self.image_height = image.height();
 
-        let texture = load_texture(gl, image)?;
+        let texture = load_texture(&self.gl, image)?;
 
         unsafe {
             // Delete from memory the previous texture
-            gl.DeleteTextures(1, &self.texture);
+            self.gl.DeleteTextures(1, &self.texture);
         }
         self.texture = texture;
 
         Ok(())
+    }
+
+    pub fn get_image_height(&self) -> u32 {
+        self.image_height
+    }
+
+    pub fn get_image_width(&self) -> u32 {
+        self.image_width
+    }
+}
+
+impl Drop for Wallpaper {
+    fn drop(&mut self) {
+        unsafe { self.gl.DeleteTextures(1, &self.texture) };
     }
 }


### PR DESCRIPTION
When the previous wallpaper was replaced,
nothing was cleaning up the texture.

This is achieved by moving the destruction of the texture to the wallpaper code. This way we know it will be destroyed each time.

Without this fix I have the same or a similar issue as #81.