### PR TITLE
fix compile

### DIFF
--- a/daemon/src/render/shader.rs
+++ b/daemon/src/render/shader.rs
@@ -12,7 +12,7 @@ use super::gl;
 pub unsafe fn create_shader(
     gl: &gl::Gl,
     shader: gl::types::GLenum,
-    sources: &[*const i8],
+    sources: &[*const u8],
 ) -> Result<gl::types::GLuint> {
     let shader = gl.CreateShader(shader);
     gl_check!(gl, "calling CreateShader");


### PR DESCRIPTION
When I was trying to build the master branch (to see whether it fixes https://github.com/danyspin97/wpaperd/issues/85) with Nix by overriding the `src` and `cargoDeps` from the nixpkgs/nixos-unstable package (I only saw that this repo has a Nix flake later); I got the following compile time error:
```
wpaperd> error[E0308]: mismatched types
wpaperd>    --> daemon/src/render/renderer.rs:436:68
wpaperd>     |
wpaperd> 436 |         let vertex_shader = create_shader(gl, gl::VERTEX_SHADER, &[VERTEX_SHADER_SOURCE.as_ptr()])
wpaperd>     |                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const i8`, found `*const u8`
wpaperd>     |
wpaperd>     = note: expected raw pointer `*const i8`
wpaperd>                found raw pointer `*const u8`
wpaperd> error[E0308]: mismatched types
wpaperd>    --> daemon/src/render/renderer.rs:442:15
wpaperd>     |
wpaperd> 442 |             &[FRAGMENT_SHADER_SOURCE.as_ptr(), shader.as_ptr()],
wpaperd>     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const i8`, found `*const u8`
wpaperd>     |
wpaperd>     = note: expected raw pointer `*const i8`
wpaperd>                found raw pointer `*const u8`
wpaperd> For more information about this error, try `rustc --explain E0308`.
wpaperd> error: could not compile `wpaperd` (bin "wpaperd") due to 2 previous errors
error: builder for '/nix/store/z6k4yk1ykl63kag5hxl9mxlfcm31qz6n-wpaperd-1.0.1.drv' failed with exit code 101;
       last 10 log lines:
       >    --> daemon/src/render/renderer.rs:442:15
       >     |
       > 442 |             &[FRAGMENT_SHADER_SOURCE.as_ptr(), shader.as_ptr()],
       >     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const i8`, found `*const u8`
       >     |
       >     = note: expected raw pointer `*const i8`
       >                found raw pointer `*const u8`
       >
       > For more information about this error, try `rustc --explain E0308`.
       > error: could not compile `wpaperd` (bin "wpaperd") due to 2 previous errors
```

I just followed the instructions from the error message and changed the type of a function parameter without really understanding the code. But it compiles, and works on my machine.