### PR TITLE
lower minimum GLSL ES version to 3.10

### DIFF
--- a/daemon/src/render/shader.rs
+++ b/daemon/src/render/shader.rs
@@ -53,7 +53,7 @@ pub unsafe fn create_shader(
 }
 
 pub const VERTEX_SHADER_SOURCE: &CStr = c"
-#version 320 es
+#version 310 es
 precision mediump float;
 
 layout (location = 0) in vec2 aPosition;
@@ -69,7 +69,7 @@ void main() {
 }";
 
 pub const FRAGMENT_SHADER_SOURCE: &CStr = c"
-#version 320 es
+#version 310 es
 precision mediump float;
 out vec4 FragColor;
 


### PR DESCRIPTION
While testing https://github.com/danyspin97/wpaperd/pull/87 on my Lenovo Duet Chromebook (Mediatek MT8183 SoC, ARM Mali-G72 MP3 GPU) running NixOS, I got an error message that GLSL ES 3.20 is required while my machine only supports 3.10:
```
The application panicked (crashed).
Message:  vertex shader creation succeed: 
   0: 0:2(10): error: GLSL ES 3.20 is not supported. Supported versions are: 1.00 ES, 3.00 ES, and 3.10 ES
      

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
Location: daemon/src/render/renderer.rs:437

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

While I have **absolutely no idea** about GLSL shaders or graphics programming; I thought it to be strange that a machine that can run 3D games would not be able to render a simple background image transition.
So I just gave it a try and lowered the minimum version to 310, and it works.
I don't know, maybe an even lower version would also work?