### PR TITLE
chore(nix): Update flake and fix eval warning

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721379653,
-        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
+        "lastModified": 1729256560,
+        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
         "type": "github"
       },
       "original": {
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721528458,
-        "narHash": "sha256-uruH/EV8Rpa/CRxn8CiMzhoA6tJe8qO5c8NdgP1g0rM=",
+        "lastModified": 1729391507,
+        "narHash": "sha256-as0I9xieJUHf7kiK2a9znDsVZQTFWhM1pLivII43Gi0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0b2b2da1dad1c675c45d9e23c75674de969de83b",
+        "rev": "784981a9feeba406de38c1c9a3decf966d853cca",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
           packages = [
             pkg-config
             wayland
-            glew-egl
+            glew
           ];
         };
       });

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,10 +3,10 @@
   rustPlatform,
   pkg-config,
   wayland,
-  glew-egl,
+  glew,
   version ? "git",
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "wpaperd";
   inherit version;
 
@@ -22,11 +22,10 @@ rustPlatform.buildRustPackage rec {
     pkg-config
   ];
 
-  buildInputs =
-    [
-      wayland
-      glew-egl
-    ];
+  buildInputs = [
+    wayland
+    glew
+  ];
 
   cargoLock.lockFile = ../Cargo.lock;
 


### PR DESCRIPTION
Updated flake.lock and fixed the following evaluation warning:

`evaluation warning: 'glew-egl' is now provided by 'glew' directly`

@yunfachi 
FYI as package maintainer