### PR TITLE
Match output descriptions in addition to output names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `fit-border-color` background mode
 - Add `initial-transition` configuration to disable the startup transition if needed
 - Add `group` configuration to share the same wallpaper between multiple displays
+- Match displays using their name or their description (fixes #90)
 
 # 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -172,9 +172,13 @@ path = "/home/danyspin97/default_wallpaper.png"
 
 [DP-3]
 path = "/home/danyspin97/Wallpapers"
+
+[Dell Inc. DELL U2419H GY1VSS2]
+path = "/home/danyspin97/Wallpapers/1080p"
 ```
 
-If you're running sway, you can look for the available outputs and their ID by running:
+If you're running sway, you can look for the available outputs and
+their ID (or description) by running:
 
 ```bash
 $ swaymsg -t get_outputs
@@ -185,6 +189,8 @@ On Hyprland you can run:
 ```bash
 $ hyprctl monitors
 ```
+
+Output descriptions take priority over output IDs.
 
 ## FAQ
 

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -355,9 +355,20 @@ impl Config {
         Ok(config)
     }
 
-    pub fn get_output_by_name(&self, name: &str) -> Result<WallpaperInfo> {
+    pub fn get_info_for_output(&self, name: &str, description: &str) -> Result<WallpaperInfo> {
+        let mut cleaned = String::from(description);
+
+        // Wayland may report an output description that includes
+        // information about the port and port type.  This information
+        // is *not* reported by sway so we need to strip it off so
+        // outputs are matched the way users expect.
+        if let Some(offset) = cleaned.rfind(" (") {
+            cleaned.truncate(offset);
+        }
+
         self.data
-            .get(name)
+            .get(&cleaned)
+            .or_else(|| self.data.get(name))
             .unwrap_or(&self.any)
             .apply_and_validate(&self.default)
     }

--- a/daemon/src/display_info.rs
+++ b/daemon/src/display_info.rs
@@ -6,6 +6,7 @@ use smithay_client_toolkit::{
 #[derive(Debug)]
 pub struct DisplayInfo {
     pub name: String,
+    pub description: String,
     pub width: i32,
     pub height: i32,
     pub scale: i32,
@@ -16,6 +17,7 @@ impl DisplayInfo {
     pub fn new(info: OutputInfo) -> Self {
         Self {
             name: info.name.unwrap_or_default(),
+            description: info.description.unwrap_or_default(),
             width: 0,
             height: 0,
             scale: info.scale_factor,

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -264,6 +264,10 @@ impl Surface {
         self.info.borrow().name.to_string()
     }
 
+    pub fn description(&self) -> String {
+        self.info.borrow().description.to_string()
+    }
+
     /// Resize the surface
     pub fn resize(&mut self, qh: &QueueHandle<Wpaperd>) -> Result<()> {
         let info = self.info.borrow();

--- a/daemon/src/wpaperd.rs
+++ b/daemon/src/wpaperd.rs
@@ -72,7 +72,9 @@ impl Wpaperd {
 
     pub fn update_surfaces(&mut self, ev_handle: LoopHandle<Wpaperd>, qh: &QueueHandle<Wpaperd>) {
         for surface in &mut self.surfaces {
-            let res = self.config.get_output_by_name(&surface.name());
+            let name = surface.name();
+            let description = surface.description();
+            let res = self.config.get_info_for_output(&name, &description);
             match res {
                 Ok(wallpaper_info) => {
                     surface.update_wallpaper_info(&ev_handle, qh, wallpaper_info);
@@ -186,6 +188,11 @@ impl OutputHandler for Wpaperd {
             .as_ref()
             .map(|name| name.to_string())
             .unwrap_or_else(|| "unnamed".to_string());
+        let description = info
+            .description
+            .as_ref()
+            .map(|description| description.to_string())
+            .unwrap_or_else(|| "no-description".to_string());
         let display_info = DisplayInfo::new(info);
 
         let layer = self.layer_state.create_layer_surface(
@@ -221,7 +228,7 @@ impl OutputHandler for Wpaperd {
             }
         };
 
-        let wallpaper_info = match self.config.get_output_by_name(&name) {
+        let wallpaper_info = match self.config.get_info_for_output(&name, &description) {
             Ok(wallpaper_info) => wallpaper_info,
             Err(err) => {
                 warn!(


### PR DESCRIPTION
Allow users to specify an output using its description, so it doesn't matter which physical port it is plugged into.

Fixes #90 