### PR TITLE
daemon/config: Use regex to match info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned-vec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1569,6 +1578,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +2363,7 @@ dependencies = [
  "new_mime_guess",
  "nix",
  "rand",
+ "regex",
  "serde",
  "serde_json",
  "smithay-client-toolkit",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -38,6 +38,7 @@ khronos-egl = { version = "6.0.0", features = [ "static" ] }
 format-bytes = "0.3.0"
 ctrlc = { version = "3.4.5", features = ["termination"] }
 tikv-jemallocator = { version = "0.6.0", optional = true}
+regex = "1.9.6"
 
 [build-dependencies]
 clap = { version = "4.5.21", features = ["derive", "cargo"] }

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -340,21 +340,46 @@ impl Config {
     }
 
     pub fn get_info_for_output(&self, name: &str, description: &str) -> Result<WallpaperInfo> {
-        let mut cleaned = String::from(description);
-
-        // Wayland may report an output description that includes
-        // information about the port and port type.  This information
-        // is *not* reported by sway so we need to strip it off so
-        // outputs are matched the way users expect.
-        if let Some(offset) = cleaned.rfind(" (") {
-            cleaned.truncate(offset);
+        use regex::Regex;
+        // Actually, wayland may report an output description in different
+        // formats as the compositors wants to. For example, niri reports
+        // description in format `<vendor name> - <monitor name> - <port name>`
+        // so, we can not handle here the all formats at once. But users
+        // can use a regex to match theirs' compositors outputs.
+        let mut matched = None;
+        for (k, v) in self.data.iter() {
+            if !k.starts_with("re:") {
+                continue;
+            }
+            // TODO(Shvedov): Better to compile re withing creation of
+            // WallpaperInfo, but adding field of type `Option<Regex>` breaks
+            // PatialEq macro.
+            let re = Regex::new(&k[3..]).unwrap();
+            if re.is_match(description) {
+                matched = Some(v);
+                break;
+            };
         }
 
-        self.data
-            .get(&cleaned)
-            .or_else(|| self.data.get(name))
-            .unwrap_or(&self.any)
-            .apply_and_validate(&self.default)
+        if let Some(info) = matched {
+            info.apply_and_validate(&self.default)
+        } else {
+            let mut cleaned = String::from(description);
+
+            // Wayland may report an output description that includes
+            // information about the port and port type.  This information
+            // is *not* reported by sway so we need to strip it off so
+            // outputs are matched the way users expect.
+            if let Some(offset) = cleaned.rfind(" (") {
+                cleaned.truncate(offset);
+            }
+
+            self.data
+                .get(&cleaned)
+                .or_else(|| self.data.get(name))
+                .unwrap_or(&self.any)
+                .apply_and_validate(&self.default)
+        }
     }
 
     pub fn listen_to_changes(&self, hotwatch: &mut Hotwatch, ping: Ping) -> Result<()> {


### PR DESCRIPTION
Wayland may report an output description in different formats as the compositors wants to. For example, niri reports description in format `<vendor name> - <monitor name> - <port name>` so, we can not handle here the all formats at once. But users can use a regex to match theirs' compositors outputs.