### PR TITLE
Optional Bash Script Execution

### DIFF
--- a/daemon/src/wallpaper_info.rs
+++ b/daemon/src/wallpaper_info.rs
@@ -43,6 +43,7 @@ pub struct WallpaperInfo {
 
     /// Recursively iterate the directory set as path
     pub recursive: Option<Recursive>,
+    pub exec: Option<PathBuf>,
 }
 
 impl Default for WallpaperInfo {
@@ -59,6 +60,7 @@ impl Default for WallpaperInfo {
             transition: Transition::Fade {},
             offset: None,
             recursive: None,
+            exec: None,
         }
     }
 }


### PR DESCRIPTION
Added an optional parameter `exec` to the config, this parameter should be a path to a bash script which will execute every time a wallpaper changes.

Intended use is for you to be able to provide a script to update pywal or any other commands you'd like to run.
Example Bash Script.
```bash

#!/bin/bash

wallpaper=$(wpaperctl get-wallpaper DP-1)

# Update Pywal
echo ":: Applying pywal with $wallpaper"
wal -q -i "$wallpaper"
source "$HOME/.cache/wal/colors.sh"

exit 0
```