### PR TITLE
fix(image_picker): Remove legacy code, fixing random sorting

### DIFF
--- a/daemon/src/image_picker.rs
+++ b/daemon/src/image_picker.rs
@@ -396,9 +396,7 @@ impl ImagePicker {
             (Some(ImagePickerAction::Next), ImagePickerSorting::GroupedRandom(group)) => {
                 let mut group = group.group.borrow_mut();
                 let queue = &mut group.queue;
-                if queue.has_reached_end() || queue.buffer.get(index).is_none() {
-                    queue.push(img_path.clone());
-                }
+                queue.push(img_path.clone());
                 group.loading_image = None;
                 group.current_image.clone_from(&img_path);
                 group.index = index;


### PR DESCRIPTION
Ciao,
things have changed over the past few months, but the issue we discussed in #98 still seems to be present in the latest release, at least on my end. Unfortunately, I haven't had much time lately, so I haven't been able to investigate it further.

This PR is a follow-up to issue #98. Long story short: random sorting sometimes gets stuck, and we found that the cause was an old piece of logic, which you partially fixed in commit `66866af`. This PR addresses that issue, and in my testing over the past few days, I haven't encountered any further problems.

If you need a video demonstration or additional testing, I’ll be happy to provide that later this week.

Thanks again for your hard work!