### PR TITLE
ci: check that `Cargo.lock` has been updated

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -87,6 +87,21 @@ jobs:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true
 
+  update:
+    name: Check Cargo.lock
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Check if Cargo.lock needs to be updated
+        run: cargo update -w --locked
+
   audit:
     name: Audit
     runs-on: ubuntu-latest


### PR DESCRIPTION
Following up from #138, this adds a new step to the CI to check that the `Cargo.lock` file has been updated