### PR TITLE
change 'rinstall --yes' to 'rinstall install --yes'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ scdoc < man/wpaperd-output.5.scd > man/wpaperd-output.5
 
 You can install both the daemon (`wpaperd`) and cli (`wpaperctl`) using **rinstall**:
 ```bash
-$ rinstall --yes
+$ rinstall install --yes
 ```
 
 To run _wpaperd_, run the **daemon**:


### PR DESCRIPTION
in the original readme, the user is instructed to install the package using the rinstall command like so: rinstall --yes
however, to actually install the package, the user would need to enter that command with 'install' betten the 'rinstall' and the '--yes', so it would be rinstall --yes