### PR TITLE
feat: add cover mode for wallpaper rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ represents a different display and can contain the following keys:
   - `fit` shows the entire image with black corners covering the empty space left
   - `fit-border-color` works like `fit`, but fill the empty space with the color of the border
     of the image; suggested for images that have a solid color in their border
+  - `cover` scales the image to fill the entire screen while maintaining aspect ratio, potentially
+    cropping parts of the image
   - `center` centers the image on the screen, leaving out the corners of the image that couldn't fit
   - `stretch` shows the entire image stretching it to fit the entire screen without leaving any
     black corner, changing the aspect ratio

--- a/daemon/src/render/renderer.rs
+++ b/daemon/src/render/renderer.rs
@@ -195,6 +195,16 @@ impl Renderer {
                         (display_height / height).max(1.0),
                     ]
                 }
+                BackgroundMode::Cover => {
+                    // Cover mode scales image to fill screen while maintaining aspect ratio
+                    // Use min() scaling to ensure entire screen is covered (opposite of Fit)
+                    let width = display_height * image_ratio;
+                    let height = display_width / image_ratio;
+                    [
+                        (display_width / width).min(1.0),
+                        (display_height / height).min(1.0),
+                    ]
+                }
                 BackgroundMode::Tile => {
                     let width_proportion = display_width / image_width * display_ratio;
                     let height_proportion = display_height / image_height * display_ratio;
@@ -263,7 +273,8 @@ impl Renderer {
                     BackgroundMode::Stretch
                     | BackgroundMode::Center
                     | BackgroundMode::Fit
-                    | BackgroundMode::FitBorderColor,
+                    | BackgroundMode::FitBorderColor
+                    | BackgroundMode::Cover,
                 ) => 0.5,
                 (None, BackgroundMode::Tile) => 0.0,
                 (Some(offset), _) => offset,
@@ -277,9 +288,10 @@ impl Renderer {
             self.check_error("Failed to set the value for the uniform texture_offset")?;
 
             let texture_wrap = match mode {
-                BackgroundMode::Stretch | BackgroundMode::Center | BackgroundMode::Fit => {
-                    gl::CLAMP_TO_BORDER_EXT
-                }
+                BackgroundMode::Stretch
+                | BackgroundMode::Center
+                | BackgroundMode::Fit
+                | BackgroundMode::Cover => gl::CLAMP_TO_BORDER_EXT,
                 BackgroundMode::Tile => gl::REPEAT,
                 BackgroundMode::FitBorderColor => gl::CLAMP_TO_EDGE,
             } as i32;

--- a/daemon/src/wallpaper_info.rs
+++ b/daemon/src/wallpaper_info.rs
@@ -87,4 +87,5 @@ pub enum BackgroundMode {
     Fit,
     Tile,
     FitBorderColor,
+    Cover,
 }

--- a/man/wpaperd-output.5.scd
+++ b/man/wpaperd-output.5.scd
@@ -43,6 +43,8 @@ represents a different display and can contain the following keys:
 - `mode`, choose how to display the wallpaper when the size is different than the display
   resolution:
   - `fit` shows the entire image with black corners covering the empty space left
+  - `cover` scales the image to fill the entire screen while maintaining aspect ratio, potentially
+    cropping parts of the image
   - `center` centers the image on the screen, leaving out the corners of the image that couldn't fit
   - `stretch` shows the entire image stretching it to fit the entire screen without leaving any
     black corner, changing the aspect ratio
@@ -51,7 +53,7 @@ represents a different display and can contain the following keys:
 - `queue_size`, decide how big the queue should be when `path` is set a directory and `sorting` is
    set to `random`. (_Optional_, `10` by default)
 - `initial_transition`, whether or not to transition from the initial black screen (_Optional_, `true` by default)
-  
+
 
 ## DEFAULT SECTION
 


### PR DESCRIPTION
This adds a new "cover" background mode that scales wallpapers to fill the entire screen while maintaining aspect ratio. Unlike "fit" mode which may leave black bars, cover mode ensures full screen coverage by cropping parts of the image that extend beyond screen boundaries when aspect ratios differ.

---
Hey there. My wallpapers normally have the right aspect ratio for one of my screen (16:10), but my laptop screen is actually 3:2 so some small adjustments are necessary. Since I don't like black bars, I added this, and I've now been using this for 6 weeks without any issue 😊 The name `cover` is also used by CSS (`background-size: cover` and `object-fit: cover`), swww, and probably others.