### PR TITLE
Exit with code 1 when wpaperctl encounters an error

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -143,15 +143,18 @@ fn main() {
             }
             IpcResponse::Ok => (),
         },
-        Err(err) => match err {
-            IpcError::MonitorNotFound { monitor } => {
-                eprintln!("monitor {monitor} could not be found")
-            }
-            IpcError::DrawErrors(errors) => {
-                for (monitor, err) in errors {
-                    eprintln!("Wallpaper could not be drawn for monitor {monitor}: {err}")
+        Err(err) => {
+            match err {
+                IpcError::MonitorNotFound { monitor } => {
+                    eprintln!("monitor {monitor} could not be found")
+                }
+                IpcError::DrawErrors(errors) => {
+                    for (monitor, err) in errors {
+                        eprintln!("Wallpaper could not be drawn for monitor {monitor}: {err}")
+                    }
                 }
             }
-        },
+            std::process::exit(1);
+        }
     }
 }


### PR DESCRIPTION
`wpaperctl` now exits with code `1` when it encounters an error, rather than returning `0` after printing to stderr. This should help, @franalbani, with those callback integration failures. Shell conditionals and set -e scripts should now behave as expected.

Fixes #159