### PR TITLE
Allow running multiple instances with different surface namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The configuration file for *wpaperd* is located in `XDG_CONFIG_HOME/wpaperd/conf
 There are some top-level options for configuring general wpaperd behavior, and sections for configuring the wallpapers. The top-level options are:
 
 - `layer_namespace`, the prefix for the `wlr_layer_shell` layer surface's namespace. _Optional_, defaults to `wpaperd`
+- `socket_name`, the name used for the IPC socket. Can be specified in `wpaperctl` with the `-s` flag. _Optional_, defaults to `wpaperd`
 
 Each section represents a different display and can contain the following keys:
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,13 @@ $ wpaperctl toggle-pause
 ## Wallpaper Configuration
 
 The configuration file for *wpaperd* is located in `XDG_CONFIG_HOME/wpaperd/config.toml`
-(which defaults to `~/.config/wpaperd/config.toml`). Each section
-represents a different display and can contain the following keys:
+(which defaults to `~/.config/wpaperd/config.toml`).
+
+There are some top-level options for configuring general wpaperd behavior, and sections for configuring the wallpapers. The top-level options are:
+
+- `layer_namespace`, the prefix for the `wlr_layer_shell` layer surface's namespace. _Optional_, defaults to `wpaperd`
+
+Each section represents a different display and can contain the following keys:
 
 - `path`, path to the image to use as wallpaper or to a directory to pick the wallpaper from
 - `duration`, how much time the image should be displayed until it is changed with a new one.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
 
     let mut json_resp = false;
 
-    let mut conn = UnixStream::connect(socket_path().unwrap()).unwrap();
+    let mut conn = UnixStream::connect(socket_path(args.socket_name.as_deref()).unwrap()).unwrap();
     let msg = match args.subcmd {
         SubCmd::GetWallpaper { monitor } => IpcMessage::CurrentWallpaper {
             monitor: unquote(monitor),

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -5,6 +5,8 @@ use clap::Parser;
 pub struct Opts {
     #[clap(subcommand)]
     pub subcmd: SubCmd,
+    #[clap(short, long)]
+    pub socket_name: Option<String>,
 }
 
 #[derive(clap::Subcommand)]

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -283,6 +283,7 @@ impl SerializedWallpaperInfo {
 pub struct Config {
     #[serde(flatten)]
     data: HashMap<String, SerializedWallpaperInfo>,
+    pub layer_namespace: Option<String>,
     #[serde(skip)]
     default: SerializedWallpaperInfo,
     #[serde(skip)]

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -284,6 +284,7 @@ pub struct Config {
     #[serde(flatten)]
     data: HashMap<String, SerializedWallpaperInfo>,
     pub layer_namespace: Option<String>,
+    pub socket_name: Option<String>,
     #[serde(skip)]
     default: SerializedWallpaperInfo,
     #[serde(skip)]

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -159,6 +159,8 @@ fn run(opts: Opts, xdg_dirs: BaseDirectories) -> Result<()> {
         .wrap_err("Failed to insert the image loader listener into the event loop")?;
     let image_loader = Rc::new(RefCell::new(ImageLoader::new(image_loader_ping)));
 
+    let socket_name = config.socket_name.clone();
+
     let mut wpaperd = Wpaperd::new(
         &qh,
         &globals,
@@ -171,8 +173,10 @@ fn run(opts: Opts, xdg_dirs: BaseDirectories) -> Result<()> {
     .wrap_err("Failed to initiliaze wpaperd status")?;
 
     // Start listening on the IPC socket
-    let socket = listen_on_ipc_socket(&socket_path().wrap_err("Failed to locate wpaperd socket")?)
-        .wrap_err("Failed to listen to IPC socket")?;
+    let socket = listen_on_ipc_socket(
+        &socket_path(socket_name.as_deref()).wrap_err("Failed to locate wpaperd socket")?,
+    )
+    .wrap_err("Failed to listen to IPC socket")?;
 
     // Add source to calloop loop.
     event_loop

--- a/daemon/src/wpaperd.rs
+++ b/daemon/src/wpaperd.rs
@@ -204,7 +204,14 @@ impl OutputHandler for Wpaperd {
             qh,
             surface.clone(),
             Layer::Background,
-            Some(format!("wpaperd-{name}")),
+            Some(format!(
+                "{}-{name}",
+                self.config
+                    .layer_namespace
+                    .as_ref()
+                    .and_then(|s| Some(s.as_str()))
+                    .unwrap_or("wpaperd")
+            )),
             Some(&output),
         );
         layer.set_anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT | Anchor::BOTTOM);

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -36,7 +36,10 @@ pub enum IpcError {
     DrawErrors(Vec<(String, String)>),
 }
 
-pub fn socket_path() -> Result<PathBuf, BaseDirectoriesError> {
-    let xdg_dirs = BaseDirectories::with_prefix("wpaperd")?;
-    Ok(xdg_dirs.get_runtime_directory()?.join("wpaperd.sock"))
+pub fn socket_path(name: Option<&str>) -> Result<PathBuf, BaseDirectoriesError> {
+    let name = name.unwrap_or("wpaperd");
+    let xdg_dirs = BaseDirectories::with_prefix(name)?;
+    Ok(xdg_dirs
+        .get_runtime_directory()?
+        .join(format!("{name}.sock")))
 }

--- a/man/wpaperd-output.5.scd
+++ b/man/wpaperd-output.5.scd
@@ -30,8 +30,15 @@ $ hyprctl monitors
 ```
 
 The configuration file for *wpaperd* is located in `XDG_CONFIG_HOME/wpaperd/config.toml`
-(which defaults to `~/.config/wpaperd/config.toml`). Each section
-represents a different display and can contain the following keys:
+(which defaults to `~/.config/wpaperd/config.toml`).
+
+There are some top-level options for configuring general wpaperd behavior, and sections for
+configuring the wallpapers. The top-level options are:
+
+- `layer_namespace`, the prefix for the `wlr_layer_shell` layer surface's namespace.
+  _Optional_, defaults to `wpaperd`
+
+Each section represents a different display and can contain the following keys:
 
 - `path`, path to the image to use as wallpaper or to a directory to pick the wallpaper from
 - `duration`, how much time the image should be displayed until it is changed with a new one.

--- a/man/wpaperd-output.5.scd
+++ b/man/wpaperd-output.5.scd
@@ -37,6 +37,8 @@ configuring the wallpapers. The top-level options are:
 
 - `layer_namespace`, the prefix for the `wlr_layer_shell` layer surface's namespace.
   _Optional_, defaults to `wpaperd`
+- `socket_name`, the name used for the IPC socket. Can be specified in `wpaperctl` with the
+  `-s` flag. _Optional_, defaults to `wpaperd`
 
 Each section represents a different display and can contain the following keys:
 


### PR DESCRIPTION
Add:
- top-level `layer_namespace` config option for configuring the layer surface namespace
- top-level `socket_name` config option for configuring the IPC socket name
- corresponding `-s`/`--socket-name` CLI flag to `wpaperctl`

All of the above default to `wpaperd`, so there should be no change in behavior if the options are not specified.

My usecase for this is [showing a wallpaper in the Niri overview backdrop](https://yalter.github.io/niri/Configuration%3A-Layer-Rules.html#place-within-backdrop). That requires two instances of wpaperd, with different layer surface namespaces so I can match on that.