### PR TITLE
Use `highp` for fragment shader

### DIFF
--- a/daemon/src/render/shader.rs
+++ b/daemon/src/render/shader.rs
@@ -70,7 +70,7 @@ void main() {
 
 pub const FRAGMENT_SHADER_SOURCE: &CStr = c"
 #version 310 es
-precision mediump float;
+precision highp float;
 out vec4 FragColor;
 
 in vec2 v_texcoord;


### PR DESCRIPTION
I'm not sure why it was set to `mediump`, but changing it to `highp` fixes #126 for me. With this the wallpaper now looks exactly the same as with `swaybg` or `hyprpaper` (which [also uses `highp`](https://github.com/hyprwm/hyprtoolkit/blob/main/src/renderer/gl/shaders/glsl/rgba.frag#L4)).