### PR TITLE
fix: handle wallpaper link to missing image file

### DIFF
--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -848,16 +848,19 @@ impl Surface {
     /// Add a symlink into .local/state that points to the current wallpaper
     fn update_wallpaper_link(&self, image_path: &Path) {
         let link = self.xdg_state_home.join(self.name());
-        // remove the previous file if it exists, otherwise symlink() fails
-        if link.exists() {
-            if let Err(err) = fs::remove_file(&link)
-                .wrap_err_with(|| format!("Failed to remove symlink {link:?}"))
-            {
+
+        // remove the previous file if it exists, otherwise symlink() fails. If
+        // no file exists, remove_file will return an error of kind NotFound and
+        // in that case we ignore the error.
+        if let Err(err) = fs::remove_file(&link) {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                let err = eyre!(err).wrap_err(format!("Failed to remove symlink {link:?}"));
                 warn!("{err:?}");
                 // Do no try to create a new symlink
                 return;
             }
         }
+
         if let Err(err) = std::os::unix::fs::symlink(image_path, &link)
             .wrap_err_with(|| format!("Failed to create symlink {link:?} to {image_path:?}"))
         {


### PR DESCRIPTION
This ensures that the wallpaper link is removed even if the target file is gone. Previously, the `exists` call would return false since it follows the existing wallpaper link. The symlink is therefore not actually removed and the following symlink call fails with the error

    WARN [wpaperd::surface]
       0: Failed to create symlink "{link}" to "{image path}"
       1: File exists (os error 17)

This change fixes this by simply always attempting to remove the file. If the file does not exist then remove call errors out with an NotFound. If that happens we ignore the error and continue.