### PR TITLE
fix: dpms cycle causes blurred wallpaper

### DIFF
--- a/daemon/src/render/egl_context.rs
+++ b/daemon/src/render/egl_context.rs
@@ -61,8 +61,12 @@ impl EglContext {
             .create_context(egl_display, config, None, &CONTEXT_ATTRIBUTES)
             .wrap_err("Failed to create an EGL context")?;
 
-        // First, create a small surface, we don't know the size of the output yet
-        let wl_egl_surface = WlEglSurface::new(wl_surface.id(), 10, 10)
+        let (initial_width, initial_height) = if display_info.is_configured() {
+            (display_info.adjusted_width(), display_info.adjusted_height())
+        } else {
+            (10, 10)
+        };
+        let wl_egl_surface = WlEglSurface::new(wl_surface.id(), initial_width, initial_height)
             .wrap_err("Failed to create a WlEglSurface")?;
 
         let surface = unsafe {
@@ -79,7 +83,7 @@ impl EglContext {
         egl.make_current(egl_display, Some(surface), Some(surface), Some(context))
             .wrap_err("Failed to set the current EGL context")?;
 
-        let renderer = unsafe {
+        let mut renderer = unsafe {
             Renderer::new(
                 wallpaper_info.transition_time,
                 wallpaper_info.transition.clone(),
@@ -87,6 +91,12 @@ impl EglContext {
             )
             .wrap_err("Failed to create a openGL ES renderer")?
         };
+
+        if display_info.is_configured() {
+            renderer
+                .resize(display_info)
+                .wrap_err("Failed to set the initial GL viewport")?;
+        }
 
         Ok(Self {
             display: egl_display,

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -215,10 +215,11 @@ impl Surface {
                         self.display_info.name
                     ))
                 );
-                // The draw failed for some reason. Invalid the context and try to draw in the next
-                // frame
+                // Invalidate the context so check_context will recreate it on the
+                // next event loop iteration. We intentionally don't request a frame
+                // callback here to avoid a tight error loop when the surface is
+                // temporarily invalid (e.g. after DPMS off/on).
                 self.context = None;
-                self.wl_surface.frame(qh, self.wl_surface.clone());
             }
         }
     }
@@ -865,7 +866,9 @@ impl Surface {
         }
     }
 
-    /// Check if the context is valid, and try to recreate it if needed
+    /// Check if the context is valid, and try to recreate it if needed.
+    /// When recreation fails, we avoid requesting frame callbacks to prevent
+    /// a tight error loop — recovery will happen on the next real event.
     #[inline]
     pub fn check_context(&mut self, egl_display: egl::Display, qh: &QueueHandle<Wpaperd>) {
         // The context is still valid
@@ -873,7 +876,7 @@ impl Surface {
             return;
         }
 
-        self.context = match EglContext::new(
+        match EglContext::new(
             egl_display,
             &self.wl_surface,
             &self.wallpaper_info,
@@ -881,6 +884,7 @@ impl Surface {
         ) {
             Ok(context) => {
                 // We were able to create a new context, so we can draw the wallpaper
+                self.context = Some(context);
                 // First we need to tell the image picker that we are not choosing a new image
                 self.image_picker.reload();
                 // Then we need to ask the background loader to load the image
@@ -897,14 +901,11 @@ impl Surface {
                         warn!("{err:?}");
                     }
                 }
-                Some(context)
             }
             Err(err) => {
                 error!("{err:?}");
-                self.wl_surface.frame(qh, self.wl_surface.clone());
-                None
             }
-        };
+        }
     }
 
     pub fn get_context(&mut self) -> Result<&mut EglContext> {


### PR DESCRIPTION
When DPMS turns off and back on, the EGL context is recreated via `check_context` but no configure event follows. `EglContext::new` always created a `10x10` placeholder surface, so the wallpaper rendered at that size and was stretched — appearing blurred.

Fix: Use real display dimensions in `EglContext::new` when known. Assign the context before drawing and remove frame callback requests from error paths to prevent a tight error loop.

For context, here is the backtrace triggered by cycling dpms off/on:

```shell
ERROR [wpaperd::surface]
   0: Failed to draw on display DP-1
   1: Failed to draw the wallpaper
   2: Failed to swap EGL buffers
   3: Failed to draw the content of the GL buffer
   4: An Surface argument does not name a valid surface (window, pixel buffer or pixmap) configured for GL rendering.

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 3 frames hidden ⋮
   4: wpaperd::render::egl_context::EglContext::draw::h2cfd419ad98f7a10
      at <unknown source file>:<unknown line>
   5: wpaperd::surface::Surface::try_drawing::h13784a2ae9118c8c
      at <unknown source file>:<unknown line>
   6: <core::slice::iter::IterMut<T> as core::iter::traits::iterator::Iterator>::for_each::hac05d0588b70c788
      at <unknown source file>:<unknown line>
   7: wpaperd::main::h2d7449a618b4ff0d
      at <unknown source file>:<unknown line>
   8: std::sys::backtrace::__rust_begin_short_backtrace::hddf1794ab0d6f4f6
      at <unknown source file>:<unknown line>
   9: std::rt::lang_start::{{closure}}::h1492e302212c8192
      at <unknown source file>:<unknown line>
  10: std::rt::lang_start_internal::hb84cc625940d332a
      at <unknown source file>:<unknown line>
  11: main<unknown>
      at <unknown source file>:<unknown line>
  12: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>
  13: _start<unknown>
      at <unknown source file>:<unknown line>
```

Tested on `Hyprland 0.54.1 built from branch v0.54.1 at commit 4b07770b9ef1cceb2e6f56d33538aaffb9186b9c`

---
*This fix was developed with AI assistance (Claude), feel free to disregard and close.*