### PR TITLE
fix(nvidia): avoid EGL_BAD_SURFACE by resizing instead of replacing surface

### DIFF
--- a/daemon/src/image_picker.rs
+++ b/daemon/src/image_picker.rs
@@ -113,10 +113,6 @@ impl Queue {
         }
     }
 
-    fn has_reached_end(&self) -> bool {
-        self.current == self.tail
-    }
-
     fn resize(&mut self, new_size: usize) {
         if !self.is_full() {
             self.buffer.reserve_exact(new_size);

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -252,7 +252,9 @@ fn run(opts: Opts, xdg_dirs: BaseDirectories) -> Result<()> {
 
             // This is only true once per surface at startup (or when a new display gets connected)
             if !surface.has_been_drawn() {
-                // Add the first timer, it will run endlessy or it will be updated in
+                // EGL context starts with 10x10 surface, resize to actual dimensions before first draw
+                surface.resize(&qh).ok();
+                // Add the first timer, it will run endlessly or it will be updated in
                 // Surface::handle_new_duration
                 surface.add_timer(&event_loop.handle(), None);
                 surface.try_drawing(&qh, None);

--- a/daemon/src/render/egl_context.rs
+++ b/daemon/src/render/egl_context.rs
@@ -121,32 +121,28 @@ impl EglContext {
     }
 
     /// Resize the surface
-    /// Resizing the surface means to destroy the previous one and then recreate it
-    pub fn resize(&mut self, wl_surface: &WlSurface, display_info: &DisplayInfo) -> Result<()> {
-        egl.destroy_surface(self.display, self.surface)
-            .wrap_err("Failed to destroy the EGL surface")?;
-        let wl_egl_surface = WlEglSurface::new(
-            wl_surface.id(),
+    ///
+    /// Rather than destroying and recreating the EGL surface, we resize the
+    /// existing `wl_egl_window` in place via `wl_egl_window_resize()`. This
+    /// avoids calling `eglDestroyS()` on the currently-bound surface, which
+    /// on NVIDIA driver 575.64+ triggers an implicit:
+    ///
+    /// eglMakeCurrent(NO_SURFACE, NO_SURFACE, NO_CONTEXT)
+    ///
+    /// That implicit release corrupts the driver's "current draw surface"
+    /// tracking, causing the next `eglSwapBuffers()` to fail with
+    /// EGL_BAD_SURFACE.
+    ///
+    /// See:
+    /// - https://forums.developer.nvidia.com/t/575-64-libegl-nvidia-so-bug-eglsurface-x-is-not-current-draw-surface/336704
+    /// - wpaperd issues #116, #129, and #149
+    pub fn resize(&mut self, display_info: &DisplayInfo) -> Result<()> {
+        self.wl_egl_surface.resize(
             display_info.adjusted_width(),
             display_info.adjusted_height(),
-        )
-        .wrap_err("Failed to create a WlEglSurface")?;
-
-        let surface = unsafe {
-            egl.create_window_surface(
-                self.display,
-                self.config,
-                wl_egl_surface.ptr() as egl::NativeWindowType,
-                None,
-            )
-            .wrap_err("Failed to create an EGL window surface")?
-        };
-
-        self.surface = surface;
-        self.wl_egl_surface = wl_egl_surface;
-
-        self.make_current()
-            .wrap_err("Failed to switch to the EGL context")?;
+            0,
+            0,
+        );
         self.renderer
             .resize(display_info)
             .wrap_err("Failed to resize GL window")?;
@@ -177,12 +173,28 @@ impl EglContext {
         self.renderer
             .clear_after_draw()
             .wrap_err("Failed to unbind the buffer")?;
-        self.swap_buffers().wrap_err("Failed to swap EGL buffers")?;
 
-        // Reset the context
-        egl::API
-            .make_current(self.display, None, None, None)
-            .wrap_err("Failed to reset the EGL context")
+        // We intentionally do not release the EGL context after swapping
+        // buffers. libEGL_nvidia.so in NVIDIA driver 575.64+ appears to have
+        // a bug which causes:
+        //
+        // eglMakeCurrent(dpy, NO_SURFACE, NO_SURFACE, NO_CONTEXT)
+        //
+        // Followed by a subsequent:
+        //
+        // eglMakeCurrent(dpy, surf, surf, ctx)
+        //
+        // To leaves the driver in a confused state, where the next call to
+        // `eglSwapBuffers()` will fail with:
+        //
+        // EGL_BAD_SURFACE ("EGLSurface is not current draw surface")
+        //
+        // Per EGL spec §3.7.3 the context is implicitly released when another
+        // surface calls make_current(), so explicit release is not necessary
+        // on a single-threaded renderer.
+        //
+        // See https://registry.khronos.org/EGL/specs/eglspec.1.5.pdf
+        self.swap_buffers().wrap_err("Failed to swap EGL buffers")
     }
 }
 

--- a/daemon/src/render/egl_context.rs
+++ b/daemon/src/render/egl_context.rs
@@ -20,7 +20,7 @@ use super::Renderer;
 pub struct EglContext {
     display: egl::Display,
     context: egl::Context,
-    config: egl::Config,
+    _config: egl::Config,
     wl_egl_surface: WlEglSurface,
     surface: khronos_egl::Surface,
     display_name: String,
@@ -91,7 +91,7 @@ impl EglContext {
         Ok(Self {
             display: egl_display,
             context,
-            config,
+            _config: config,
             surface,
             wl_egl_surface,
             display_name: display_info.name.to_owned(),

--- a/daemon/src/render/egl_context.rs
+++ b/daemon/src/render/egl_context.rs
@@ -34,13 +34,17 @@ impl EglContext {
         wallpaper_info: &WallpaperInfo,
         display_info: &DisplayInfo,
     ) -> Result<Self> {
-        const ATTRIBUTES: [i32; 7] = [
+        const ATTRIBUTES: [i32; 11] = [
             egl::RED_SIZE,
             8,
             egl::GREEN_SIZE,
             8,
             egl::BLUE_SIZE,
             8,
+            egl::RENDERABLE_TYPE,
+            egl::OPENGL_ES2_BIT,
+            egl::SURFACE_TYPE,
+            egl::WINDOW_BIT,
             egl::NONE,
         ];
 

--- a/daemon/src/render/egl_context.rs
+++ b/daemon/src/render/egl_context.rs
@@ -79,13 +79,24 @@ impl EglContext {
         egl.make_current(egl_display, Some(surface), Some(surface), Some(context))
             .wrap_err("Failed to set the current EGL context")?;
 
-        let renderer = unsafe {
+        // Use match rather than ? so that we can clean up the EGL surface and context on
+        // failure. If we return early via ?, the egl::Surface and egl::Context locals have
+        // no Drop impl and will leak. A leaked surface prevents a subsequent
+        // eglCreateWindowSurface on the same WlSurface from succeeding (EGL_BAD_ALLOC).
+        let renderer = match unsafe {
             Renderer::new(
                 wallpaper_info.transition_time,
                 wallpaper_info.transition.clone(),
                 display_info,
             )
-            .wrap_err("Failed to create a openGL ES renderer")?
+            .wrap_err("Failed to create a openGL ES renderer")
+        } {
+            Ok(r) => r,
+            Err(err) => {
+                let _ = egl.destroy_surface(egl_display, surface);
+                let _ = egl.destroy_context(egl_display, context);
+                return Err(err);
+            }
         };
 
         Ok(Self {
@@ -204,7 +215,16 @@ impl Drop for EglContext {
             warn!(
                 "{:?}",
                 eyre!(err).wrap_err(format!(
-                    "Failed to destroy surface for display {}",
+                    "Failed to destroy EGL surface for display {}",
+                    self.display_name
+                ))
+            );
+        }
+        if let Err(err) = egl.destroy_context(self.display, self.context) {
+            warn!(
+                "{:?}",
+                eyre!(err).wrap_err(format!(
+                    "Failed to destroy EGL context for display {}",
                     self.display_name
                 ))
             );

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -360,7 +360,7 @@ impl Surface {
         self.context
             .as_mut()
             .ok_or_else(|| eyre!("EGL context is not available"))?
-            .resize(&self.wl_surface, &self.display_info)
+            .resize(&self.display_info)
             .wrap_err("Failed to resize EGL window")?;
 
         // Queue drawing for the next frame. We can directly draw here, but we would still
@@ -882,7 +882,15 @@ impl Surface {
             &self.wallpaper_info,
             &self.display_info,
         ) {
-            Ok(context) => {
+            Ok(mut context) => {
+                // EglContext::new() always starts with a 10×10 wl_egl_window. Resize it to the
+                // actual display dimensions now so we never draw to a 10×10 surface.
+                if let Err(err) = context
+                    .resize(&self.display_info)
+                    .wrap_err("Failed to resize recovered EGL context")
+                {
+                    error!("{err:?}");
+                }
                 // We were able to create a new context, so we can draw the wallpaper
                 // First we need to tell the image picker that we are not choosing a new image
                 self.image_picker.reload();

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -167,36 +167,33 @@ impl Surface {
 
     /// Returns true if something has been drawn to the surface
     fn draw(&mut self, qh: &QueueHandle<Wpaperd>, time: Option<u32>) -> Result<()> {
+        let loading_image = self.loading_image.is_some();
+        let window_drawn = self.window_drawn;
+        let adjusted_width = self.display_info.adjusted_width();
+        let adjusted_height = self.display_info.adjusted_height();
+
         // Use the correct context before drawing
-        self.get_context()?
+        let context = self.get_context()?;
+        context
             .make_current()
             .wrap_err("Failed to switch EGL context")?;
 
-        if self
-            .get_context()?
-            .renderer
-            // If we don't have any time passed, just consider the transition to be ended by using 0
-            .update_transition_status(time.unwrap_or(0))
-        {
+        // Check transition status - if running, we don't draw this frame
+        let transition_running = context.renderer.update_transition_status(time.unwrap_or(0));
+        if transition_running {
             self.queue_draw(qh);
-            // We are waiting for an image to be loaded in memory
-        } else if self.loading_image.is_some() && self.window_drawn {
             return Ok(());
         }
 
-        self.get_context()?
-            .draw()
-            .wrap_err("Failed to draw the wallpaper")?;
+        if loading_image && window_drawn {
+            return Ok(());
+        }
 
-        // Mark the entire surface as damaged
-        self.wl_surface.damage_buffer(
-            0,
-            0,
-            self.display_info.adjusted_width(),
-            self.display_info.adjusted_height(),
-        );
+        context.draw().wrap_err("Failed to draw the wallpaper")?;
 
-        // Finally, commit the surface
+        // Mark the entire surface as damaged and commit
+        self.wl_surface
+            .damage_buffer(0, 0, adjusted_width, adjusted_height);
         self.wl_surface.commit();
 
         self.window_drawn = true;

--- a/daemon/src/wpaperd.rs
+++ b/daemon/src/wpaperd.rs
@@ -131,7 +131,6 @@ impl CompositorHandler for Wpaperd {
         time: u32,
     ) {
         let surface = self.surface_from_wl_surface(surface);
-
         surface.try_drawing(qh, Some(time));
     }
 


### PR DESCRIPTION
This diff fixes some issues with NVIDIA's awful drivers. Need to validate that this doesn't lead to memory leaks or break under other drivers, but I think the reasoning is sound?

## 575.64+

Destroying the EGL surface while it's current triggers an implicit `eglMakeCurrent()` call that corrupts the driver's internal state, causing `EGL_BAD_SURFACE` "EGLSurface is not current draw surface" errors.

## 590.48+

Seems the driver returns an ES 1.1-only config as the first match for the default `EGL_RENDERABLE_TYPE`, causing `glLinkProgram` to silently fail as the ES 2.0 GLSL shaders are invalid, and `glUseProgram(bad_program) → GL_INVALID_OPERATION (1282)`.

## References

- wpaperd issues:
  - #116
  - #129
  - #149
- NVIDIA forum: https://forums.developer.nvidia.com/t/575-64-libegl-nvidia-so-bug-eglsurface-x-is-not-current-draw-surface/336704
- EGL spec §3.7.3: https://registry.khronos.org/EGL/specs/eglspec.1.5.pdf