### PR TITLE
[bugfix] Flag to support both CW and CCW rotations

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -167,6 +167,7 @@ fn run(opts: Opts, xdg_dirs: BaseDirectories) -> Result<()> {
         filelist_cache.clone(),
         image_loader,
         xdg_dirs,
+        opts.ccw_rotation,
     )
     .wrap_err("Failed to initiliaze wpaperd status")?;
 

--- a/daemon/src/opts.rs
+++ b/daemon/src/opts.rs
@@ -30,9 +30,6 @@ pub struct Opts {
         help = "Readiness fd used by wpaperd to signal that it has started correctly"
     )]
     pub notify: Option<u8>,
-    #[clap(
-        long,
-        help = "Use counter-clockwise rotation for monitors"
-    )]
+    #[clap(long, help = "Use counter-clockwise rotation for monitors")]
     pub ccw_rotation: bool,
 }

--- a/daemon/src/opts.rs
+++ b/daemon/src/opts.rs
@@ -30,4 +30,9 @@ pub struct Opts {
         help = "Readiness fd used by wpaperd to signal that it has started correctly"
     )]
     pub notify: Option<u8>,
+    #[clap(
+        long,
+        help = "Use counter-clockwise rotation for monitors"
+    )]
+    pub ccw_rotation: bool,
 }

--- a/daemon/src/render/egl_context.rs
+++ b/daemon/src/render/egl_context.rs
@@ -33,6 +33,7 @@ impl EglContext {
         wl_surface: &WlSurface,
         wallpaper_info: &WallpaperInfo,
         display_info: &DisplayInfo,
+        ccw_rotation: bool,
     ) -> Result<Self> {
         const ATTRIBUTES: [i32; 7] = [
             egl::RED_SIZE,
@@ -84,6 +85,7 @@ impl EglContext {
                 wallpaper_info.transition_time,
                 wallpaper_info.transition.clone(),
                 display_info,
+                ccw_rotation,
             )
             .wrap_err("Failed to create a openGL ES renderer")?
         };

--- a/daemon/src/render/renderer.rs
+++ b/daemon/src/render/renderer.rs
@@ -463,8 +463,8 @@ fn projection_matrix(transform: Transform) -> [f32; 4] {
         }
         Transform::_90 => {
             [
-                0.0, -1.0,
-                1.0, 0.0,
+                0.0, 1.0,
+                -1.0, 0.0,
             ]
         }
         Transform::_180 => {
@@ -475,8 +475,8 @@ fn projection_matrix(transform: Transform) -> [f32; 4] {
         }
         Transform::_270 => {
             [
-                0.0, 1.0,
-                -1.0, 0.0,
+                0.0, -1.0,
+                1.0, 0.0,
             ]
         }
         Transform::Flipped => {
@@ -487,8 +487,8 @@ fn projection_matrix(transform: Transform) -> [f32; 4] {
         }
         Transform::Flipped90 => {
             [
-                0.0, -1.0,
-                -1.0, 0.0,
+                0.0, 1.0,
+                1.0, 0.0,
             ]
         }
         Transform::Flipped180 => {
@@ -499,8 +499,8 @@ fn projection_matrix(transform: Transform) -> [f32; 4] {
         }
         Transform::Flipped270 => {
             [
-                0.0, 1.0,
-                1.0, 0.0,
+                0.0, -1.0,
+                -1.0, 0.0,
             ]
         }
         _ => unreachable!()

--- a/daemon/src/render/renderer.rs
+++ b/daemon/src/render/renderer.rs
@@ -44,6 +44,7 @@ pub struct Renderer {
     //transparent_texture: gl::types::GLuint,
     /// contains the progress of the current animation
     transition_status: TransitionStatus,
+    ccw_rotation: bool,
 }
 
 impl Renderer {
@@ -51,6 +52,7 @@ impl Renderer {
         transition_time: u32,
         transition: Transition,
         display_info: &DisplayInfo,
+        ccw_rotation: bool,
     ) -> Result<Self> {
         let gl = Rc::new(gl::Gl::load_with(|name| {
             egl.get_proc_address(name)
@@ -75,6 +77,7 @@ impl Renderer {
             prev_wallpaper,
             current_wallpaper,
             transition_status: TransitionStatus::Ended,
+            ccw_rotation,
         };
 
         renderer
@@ -387,7 +390,7 @@ impl Renderer {
     }
 
     pub unsafe fn set_projection_matrix(&self, transform: Transform) -> Result<()> {
-        let projection_matrix = projection_matrix(transform);
+        let projection_matrix = projection_matrix(transform, self.ccw_rotation);
         let loc = self
             .gl
             .GetUniformLocation(self.program, b"projection_matrix\0".as_ptr() as *const _);
@@ -453,7 +456,7 @@ fn create_program(gl: &gl::Gl, transition: Transition) -> Result<gl::types::GLui
 }
 
 #[rustfmt::skip]
-fn projection_matrix(transform: Transform) -> [f32; 4] {
+fn projection_matrix(transform: Transform, ccw_rotation: bool) -> [f32; 4] {
     match transform {
         Transform::Normal => {
             [
@@ -461,11 +464,20 @@ fn projection_matrix(transform: Transform) -> [f32; 4] {
                 0.0, 1.0,
             ]
         }
-        Transform::_90 => {
-            [
-                0.0, 1.0,
-                -1.0, 0.0,
-            ]
+        Transform::_90 => if ccw_rotation {
+            {
+                [
+                    0.0, 1.0,
+                    -1.0, 0.0,
+                ]
+            }
+        } else {
+            {
+                [
+                    0.0, -1.0,
+                    1.0, 0.0,
+                ]
+            }
         }
         Transform::_180 => {
             [
@@ -473,11 +485,20 @@ fn projection_matrix(transform: Transform) -> [f32; 4] {
                 0.0, -1.0,
             ]
         }
-        Transform::_270 => {
-            [
-                0.0, -1.0,
-                1.0, 0.0,
-            ]
+        Transform::_270 => if ccw_rotation {
+            {
+                [
+                    0.0, -1.0,
+                    1.0, 0.0,
+                ]
+            }
+        } else {
+            {
+                [
+                    0.0, 1.0,
+                    -1.0, 0.0,
+                ]
+            }
         }
         Transform::Flipped => {
             [
@@ -485,11 +506,20 @@ fn projection_matrix(transform: Transform) -> [f32; 4] {
                 0.0, 1.0,
             ]
         }
-        Transform::Flipped90 => {
-            [
-                0.0, 1.0,
-                1.0, 0.0,
-            ]
+        Transform::Flipped90 => if ccw_rotation {
+            {
+                [
+                    0.0, 1.0,
+                    1.0, 0.0,
+                ]
+            }
+        } else {
+            {
+                [
+                    0.0, -1.0,
+                    -1.0, 0.0,
+                ]
+            }
         }
         Transform::Flipped180 => {
             [
@@ -497,11 +527,20 @@ fn projection_matrix(transform: Transform) -> [f32; 4] {
                 0.0, -1.0,
             ]
         }
-        Transform::Flipped270 => {
-            [
-                0.0, -1.0,
-                -1.0, 0.0,
-            ]
+        Transform::Flipped270 => if ccw_rotation {
+            {
+                [
+                    0.0, -1.0,
+                    -1.0, 0.0,
+                ]
+            }
+        } else {
+            {
+                [
+                    0.0, 1.0,
+                    1.0, 0.0,
+                ]
+            }
         }
         _ => unreachable!()
     }

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -89,6 +89,7 @@ pub struct Surface {
     pause_reason: Option<PauseReason>,
     /// Contains the value of XDG_STATE_HOME, given by wapaperd at struct creation
     xdg_state_home: PathBuf,
+    ccw_rotation: bool,
 }
 
 impl Surface {
@@ -118,6 +119,7 @@ impl Surface {
             &wl_surface,
             &wallpaper_info,
             &display_info,
+            wpaperd.ccw_rotation,
         )
         .wrap_err_with(|| {
             format!(
@@ -148,6 +150,7 @@ impl Surface {
             loading_image_tries: 0,
             skip_next_transition: first_transition,
             xdg_state_home,
+            ccw_rotation: wpaperd.ccw_rotation,
         };
 
         // Start loading the wallpaper as soon as possible (i.e. surface creation)
@@ -878,6 +881,7 @@ impl Surface {
             &self.wl_surface,
             &self.wallpaper_info,
             &self.display_info,
+            self.ccw_rotation,
         ) {
             Ok(context) => {
                 // We were able to create a new context, so we can draw the wallpaper

--- a/daemon/src/wpaperd.rs
+++ b/daemon/src/wpaperd.rs
@@ -43,6 +43,7 @@ pub struct Wpaperd {
     pub image_loader: Rc<RefCell<ImageLoader>>,
     pub wallpaper_groups: Rc<RefCell<WallpaperGroups>>,
     pub xdg_dirs: BaseDirectories,
+    pub ccw_rotation: bool,
 }
 
 impl Wpaperd {
@@ -54,6 +55,7 @@ impl Wpaperd {
         filelist_cache: Rc<RefCell<FilelistCache>>,
         image_loader: Rc<RefCell<ImageLoader>>,
         xdg_dirs: BaseDirectories,
+        ccw_rotation: bool,
     ) -> Result<Self> {
         let shm_state = Shm::bind(globals, qh).wrap_err("Failed to bind memory state")?;
 
@@ -72,6 +74,7 @@ impl Wpaperd {
             image_loader,
             wallpaper_groups: Rc::new(RefCell::new(WallpaperGroups::new())),
             xdg_dirs,
+            ccw_rotation,
         })
     }
 


### PR DESCRIPTION
As noted in other issues (#174 and #166), for (at least) Hyprland, vertical monitors are rotated unexpectedly.  I dug into the underlying stuff and found the expected direction for the rotation transform is inconsistent across compositors:
- According to [the spec](https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_output-enum-transform) it should be counter-clockwise
- The swap-output [man-page](https://github.com/swaywm/sway/blob/6d25b100a23a17e9663cab5c286934089f2c4460/sway/sway-output.5.scd?plain=1#L107-L114) appears to say it is clockwise
- Smithay seems to use [clockwise](https://docs.rs/smithay/latest/src/smithay/backend/renderer/mod.rs.html#183-190)

Rather than make an explicit call between the more common pattern (clockwise) and the spec (counter-clockwise), I opted to add a CLI flag to opt into counter-clockwise.  The default behavior is maintained, but if you run the daemon with `--ccw-rotation`, it will reverse for vertical monitors (0 and 180 are the same regardless of direction).  I opted to use a CLI flag, as that seems to be the pattern here.