### PR TITLE
Fix up transitions

### DIFF
--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -437,7 +437,10 @@ impl Config {
                 info.path.as_ref().map(|p| {
                     (
                         p.to_path_buf(),
-                        info.recursive.or(self.default.recursive).map(Recursive::from).unwrap_or_default(),
+                        info.recursive
+                            .or(self.default.recursive)
+                            .map(Recursive::from)
+                            .unwrap_or_default(),
                     )
                 })
             })

--- a/daemon/src/image_picker.rs
+++ b/daemon/src/image_picker.rs
@@ -320,7 +320,11 @@ impl ImagePicker {
             (Some(ImagePickerAction::Previous), ImagePickerSorting::GroupedRandom(group)) => {
                 let mut group = group.group.borrow_mut();
                 let queue = &mut group.queue;
-                let (index, path) = get_previous_image_for_random(&self.current_img, queue, files.len() <= queue.len());
+                let (index, path) = get_previous_image_for_random(
+                    &self.current_img,
+                    queue,
+                    files.len() <= queue.len(),
+                );
                 if path != group.current_image {
                     group.loading_image = Some((index, path.to_path_buf()));
                 }
@@ -702,7 +706,11 @@ fn next_random_image(
     }
 }
 
-fn get_previous_image_for_random(current_image: &Path, queue: &mut Queue, wrap: bool) -> (usize, PathBuf) {
+fn get_previous_image_for_random(
+    current_image: &Path,
+    queue: &mut Queue,
+    wrap: bool,
+) -> (usize, PathBuf) {
     while let Some((prev, index)) = queue.previous(wrap) {
         if prev.exists() {
             return (index, prev.to_path_buf());

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -282,8 +282,7 @@ fn run(opts: Opts, xdg_dirs: BaseDirectories) -> Result<()> {
 fn main() -> Result<()> {
     color_eyre::install().wrap_err("Failed to inject color_eyre")?;
 
-    let xdg_dirs =
-        BaseDirectories::with_prefix("wpaperd");
+    let xdg_dirs = BaseDirectories::with_prefix("wpaperd");
 
     let opts = Opts::parse();
 
@@ -292,7 +291,9 @@ fn main() -> Result<()> {
 
     if opts.daemon {
         // If wpaperd detach, then log to files
-        logger = logger.log_to_file(FileSpec::default().directory(xdg_dirs.get_state_home().expect("HOME is not set")));
+        logger = logger.log_to_file(
+            FileSpec::default().directory(xdg_dirs.get_state_home().expect("HOME is not set")),
+        );
         match unsafe { fork()? } {
             nix::unistd::ForkResult::Parent { child: _ } => exit(0),
             nix::unistd::ForkResult::Child => {}

--- a/daemon/src/surface.rs
+++ b/daemon/src/surface.rs
@@ -178,14 +178,17 @@ impl Surface {
             .make_current()
             .wrap_err("Failed to switch EGL context")?;
 
-        // Check transition status - if running, we don't draw this frame
+        // Check transition status and draw the wallpaper
         let transition_running = context.renderer.update_transition_status(time.unwrap_or(0));
         if transition_running {
+            // Transition is running - still need to draw so the transition renders
+            context.draw().wrap_err("Failed to draw the transition")?;
             self.queue_draw(qh);
             return Ok(());
         }
 
         if loading_image && window_drawn {
+            self.queue_draw(qh);
             return Ok(());
         }
 


### PR DESCRIPTION
Without these `draw()` and `queue_draw()` invocations I don't seem to get any transition animations between wallpapers during next/previous IPC events or the automatic cycling on `*.duration`.