### PR TITLE
fix(image_loader): log invalid image formats

### DIFF
--- a/daemon/src/image_loader.rs
+++ b/daemon/src/image_loader.rs
@@ -99,19 +99,29 @@ impl ImageLoader {
                 .and_then(|file| ImageReader::new(BufReader::new(file)).with_guessed_format())
             {
                 Ok(image) => {
-                    // Notify the event loop that the image has been loaded
-                    // We need this so that Surface::load_wallpaper is called even if
-                    // wl_surface::frame doesn't get called by the compositor (e.g. a window is
-                    // fullscreen)
-                    // Do the conversion first, then the ping, otherwise we will have a race
-                    // condition
-                    let mut decoder = image.into_decoder().unwrap();
-                    let orientation = decoder.orientation().unwrap();
-                    let mut image = DynamicImage::from_decoder(decoder).unwrap();
-                    image.apply_orientation(orientation);
-                    let image = image.into_rgba8();
-                    tx.send(Some(image)).unwrap();
-                    ping_clone.ping();
+                    match image.into_decoder() {
+                        Ok(mut decoder) => {
+                            // Notify the event loop that the image has been loaded
+                            // We need this so that Surface::load_wallpaper is called even if
+                            // wl_surface::frame doesn't get called by the compositor (e.g. a window is
+                            // fullscreen)
+                            // Do the conversion first, then the ping, otherwise we will have a race
+                            // condition
+                            let orientation = decoder.orientation().unwrap();
+                            let mut image = DynamicImage::from_decoder(decoder).unwrap();
+                            image.apply_orientation(orientation);
+                            let image = image.into_rgba8();
+                            tx.send(Some(image)).unwrap();
+                            ping_clone.ping();
+                        }
+                        Err(err) => {
+                            warn!(
+                            "{:?}",
+                            eyre!(err).wrap_err(format!("Failed to decode image {path_clone:?} needed for {requester_clone}"))
+                        );
+                            tx.send(None).unwrap();
+                        }
+                    };
                 }
                 Err(err) => {
                     warn!(


### PR DESCRIPTION
Hi all,

First PR here so hope all is up to standard. Happy to update if there are any concerns or comments. Personally, I'm not happy with nested match expressions, but don't see a cleaner way.

- [X] No LLMs used
- [X] Tested both Debug and Release builds

## Description
https://github.com/danyspin97/wpaperd/issues/114 is an issue again as I am getting `wpaperd` crashes with the following in the logs:

```
The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value: Unsupported(UnsupportedError { format: Unknown, kind: Format(Unknown) })
Location: daemon/src/image_loader.rs:108
```

Have to restart wpaperd after that and try to identify which file was the culprit.

## Changes
* handle `.unwrap()` on line 108 by logging a meaningful error and returning `None` in case of Error

## New behavior
Logs the following to the console:
```
WARN [wpaperd::image_loader]
   0: Failed to decode image "/home/user/pictures/wallpapers/bad/bad.jpg" needed for DP-1
   1: The image format could not be determined
```
I haven't reviewed the code beyond this file so not sure how the application should behave after but what I observe is a different image being loaded from the same path after a few seconds following the warning print in the logs. No crashes and there is a path to the bad image in the log.

## How to reproduce

wpaperd/wallpaper.toml
```toml
path = "/home/artem/pictures/wallpapers/bad"
```
add a couple of real images to that path so there is something to load eventually
```bash
touch /home/user/pictures/wallpapers/bad/bad.jpg
wpaperd
wpaperctl next
wpaperctl next
...
```

fixes https://github.com/danyspin97/wpaperd/issues/114