### PR TITLE
docs: Update hyprland autostart in README to use lua configuration instead of hyprlang

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ If you want to automatically run it at startup, add this line to your sway confi
 exec ~/.local/bin/wpaperd -d
 ```
 
-Or in Hyprland:
+Or in Hyprland(lua syntax):
 
 ```
-exec-once=~/.local/bin/wpaperd -d
+hl.exec_cmd("~/.local/bin/wpaperd -d)
 ```
 
 ## Image formats support


### PR DESCRIPTION
The `README` showed the old hyprlang syntax to autostart wpaperd, this pr updates the syntax.
Fixes #200 